### PR TITLE
Save diary AI images

### DIFF
--- a/projects/deario/db/models.go
+++ b/projects/deario/db/models.go
@@ -12,6 +12,7 @@ type Diary struct {
 	Uid        string
 	Updated    string
 	Aifeedback string
+	Aiimage    string
 }
 
 type PushKey struct {

--- a/projects/deario/db/query.sql.go
+++ b/projects/deario/db/query.sql.go
@@ -16,7 +16,7 @@ VALUES (?,
         ?,
         datetime('now', 'localtime'),
         datetime('now', 'localtime'))
-RETURNING content, created, date, id, uid, updated, aifeedback
+RETURNING content, created, date, id, uid, updated, aifeedback, aiimage
 `
 
 type CreateDiaryParams struct {
@@ -37,6 +37,7 @@ func (q *Queries) CreateDiary(ctx context.Context, arg CreateDiaryParams) (Diary
 		&i.Uid,
 		&i.Updated,
 		&i.Aifeedback,
+		&i.Aiimage,
 	)
 	return i, err
 }
@@ -72,7 +73,7 @@ func (q *Queries) DeleteDiary(ctx context.Context, id string) error {
 
 const getDiary = `-- name: GetDiary :one
 
-SELECT content, created, date, id, uid, updated, aifeedback
+SELECT content, created, date, id, uid, updated, aifeedback, aiimage
 FROM diarys
 WHERE date = ?
   AND uid = ?
@@ -96,12 +97,13 @@ func (q *Queries) GetDiary(ctx context.Context, arg GetDiaryParams) (Diary, erro
 		&i.Uid,
 		&i.Updated,
 		&i.Aifeedback,
+		&i.Aiimage,
 	)
 	return i, err
 }
 
 const getDiaryRandom = `-- name: GetDiaryRandom :one
-SELECT content, created, date, id, uid, updated, aifeedback
+SELECT content, created, date, id, uid, updated, aifeedback, aiimage
 FROM diarys
 WHERE date IS NOT NULL
   AND uid = ?
@@ -120,6 +122,7 @@ func (q *Queries) GetDiaryRandom(ctx context.Context, uid string) (Diary, error)
 		&i.Uid,
 		&i.Updated,
 		&i.Aifeedback,
+		&i.Aiimage,
 	)
 	return i, err
 }
@@ -145,7 +148,7 @@ func (q *Queries) GetPushKey(ctx context.Context, uid string) (PushKey, error) {
 }
 
 const listDiarys = `-- name: ListDiarys :many
-SELECT content, created, date, id, uid, updated, aifeedback
+SELECT content, created, date, id, uid, updated, aifeedback, aiimage
 FROM diarys
 WHERE uid = ?
 ORDER BY created desc
@@ -174,6 +177,7 @@ func (q *Queries) ListDiarys(ctx context.Context, arg ListDiarysParams) ([]Diary
 			&i.Uid,
 			&i.Updated,
 			&i.Aifeedback,
+			&i.Aiimage,
 		); err != nil {
 			return nil, err
 		}
@@ -193,7 +197,7 @@ UPDATE diarys
 SET content = ?,
     updated = datetime('now')
 WHERE id = ?
-RETURNING content, created, date, id, uid, updated, aifeedback
+RETURNING content, created, date, id, uid, updated, aifeedback, aiimage
 `
 
 type UpdateDiaryParams struct {
@@ -212,6 +216,7 @@ func (q *Queries) UpdateDiary(ctx context.Context, arg UpdateDiaryParams) (Diary
 		&i.Uid,
 		&i.Updated,
 		&i.Aifeedback,
+		&i.Aiimage,
 	)
 	return i, err
 }
@@ -219,17 +224,19 @@ func (q *Queries) UpdateDiary(ctx context.Context, arg UpdateDiaryParams) (Diary
 const updateDiaryOfAiFeedback = `-- name: UpdateDiaryOfAiFeedback :exec
 UPDATE diarys
 SET aiFeedback = ?,
+    aiImage    = ?,
     updated    = datetime('now')
 WHERE id = ?
 `
 
 type UpdateDiaryOfAiFeedbackParams struct {
 	Aifeedback string
+	Aiimage    string
 	ID         string
 }
 
 func (q *Queries) UpdateDiaryOfAiFeedback(ctx context.Context, arg UpdateDiaryOfAiFeedbackParams) error {
-	_, err := q.db.ExecContext(ctx, updateDiaryOfAiFeedback, arg.Aifeedback, arg.ID)
+	_, err := q.db.ExecContext(ctx, updateDiaryOfAiFeedback, arg.Aifeedback, arg.Aiimage, arg.ID)
 	return err
 }
 

--- a/projects/deario/handlers/deario.go
+++ b/projects/deario/handlers/deario.go
@@ -210,7 +210,10 @@ func AiFeedback(c echo.Context) error {
 		if err != nil {
 			return err
 		}
-		return Div(Img(Style("width:320px"), Src(fmt.Sprintf("data:image/png;base64,%s", result)))).Render(c.Response().Writer)
+		return Div(
+			Input(Type("hidden"), Name("ai-image"), Value(result)),
+			Img(Style("width:320px"), Src(fmt.Sprintf("data:image/png;base64,%s", result))),
+		).Render(c.Response().Writer)
 	} else {
 		prompt := fmt.Sprintf(`아래의 내용은 나의 오늘 하루의 일기야
 		내용 : %s
@@ -241,6 +244,7 @@ func AiFeedbackSave(c echo.Context) error {
 
 	date := c.FormValue("date")
 	aiFeedback := c.FormValue("ai-feedback")
+	aiImage := c.FormValue("ai-image")
 
 	queries, err := db.GetQueries(c.Request().Context())
 	if err != nil {
@@ -259,6 +263,7 @@ func AiFeedbackSave(c echo.Context) error {
 	err = queries.UpdateDiaryOfAiFeedback(c.Request().Context(), db.UpdateDiaryOfAiFeedbackParams{
 		ID:         diary.ID,
 		Aifeedback: aiFeedback,
+		Aiimage:    aiImage,
 	})
 
 	if err != nil {
@@ -288,6 +293,13 @@ func GetAiFeedback(c echo.Context) error {
 
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "저장된 일기가 없습니다.")
+	}
+
+	if diary.Aiimage != "" {
+		return Div(
+			Input(Type("hidden"), Name("ai-image"), Value(diary.Aiimage)),
+			Img(Style("width:320px"), Src(fmt.Sprintf("data:image/png;base64,%s", diary.Aiimage))),
+		).Render(c.Response().Writer)
 	}
 
 	if diary.Aifeedback == "" {

--- a/projects/deario/query.sql
+++ b/projects/deario/query.sql
@@ -47,6 +47,7 @@ WHERE id = ?;
 -- name: UpdateDiaryOfAiFeedback :exec
 UPDATE diarys
 SET aiFeedback = ?,
+    aiImage    = ?,
     updated    = datetime('now')
 WHERE id = ?;
 

--- a/projects/deario/schema.sql
+++ b/projects/deario/schema.sql
@@ -8,7 +8,8 @@ create table diarys
         primary key,
     uid        TEXT default ''                                 not null,
     updated    TEXT default ''                                 not null,
-    aiFeedback TEXT default ''                                 not null
+    aiFeedback TEXT default ''                                 not null,
+    aiImage    TEXT default ''                                 not null
 );
 
 -- auto-generated definition


### PR DESCRIPTION
## Summary
- extend diary schema with `aiImage` column
- support saving AI-generated images in `/ai-feedback/save`
- return stored image in `/ai-feedback`
- regenerate sqlc code

## Testing
- `sh error-check.sh` *(fails: golangci-lint missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847ecac1664832f9c2410f1fde7b0db