### PR TITLE
강화된 세션/CSRF 쿠키 설정

### DIFF
--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -58,6 +58,8 @@ func RegisterFirebaseAuthMiddleware(e *echo.Echo) {
 			Path:     "/",
 			MaxAge:   86400 * 7,
 			HttpOnly: true,
+			Secure:   config.IsProdEnv(),
+			SameSite: http.SameSiteLaxMode,
 		}
 		sess.Values["uid"] = user.UID
 

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -38,6 +38,8 @@ func RegisterCommonMiddleware(e *echo.Echo, serviceName string) {
 	e.Use(middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(rate.Limit(20)))) // 1초당 20회 제한
 	e.Use(middleware.CSRFWithConfig(middleware.CSRFConfig{
 		CookieHTTPOnly: false,
+		CookieSecure:   config.IsProdEnv(),
+		CookieSameSite: http.SameSiteLaxMode,
 	}))
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		LogRequestID:  true,


### PR DESCRIPTION
## Summary
- 세션 쿠키에 `Secure`, `SameSite` 옵션 추가
- CSRF 미들웨어에서 `CookieSecure`, `CookieSameSite` 적용

## Testing
- `./error-check.sh` *(실패: network access)*

------
https://chatgpt.com/codex/tasks/task_e_684fe180f6b4832fb364d5e191d7cd16