### PR TITLE
Improve error handling and Korean logs

### DIFF
--- a/internal/ai/aiclient.go
+++ b/internal/ai/aiclient.go
@@ -12,10 +12,14 @@ import (
 )
 
 func Request(ctx context.Context, prompt string) (string, error) {
-	client, _ := genai.NewClient(ctx, &genai.ClientConfig{
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
 		APIKey:  config.EnvMap["GEMINI_AI_KEY"],
 		Backend: genai.BackendGeminiAPI,
 	})
+	if err != nil {
+		slog.Error("AI 클라이언트 생성 실패", "error", err)
+		return "", errors.New("AI 클라이언트 생성 실패")
+	}
 
 	slog.Info(fmt.Sprintf(`프롬프트 요청 : %s`, prompt))
 
@@ -33,16 +37,24 @@ func Request(ctx context.Context, prompt string) (string, error) {
 }
 
 func ImageRequest(ctx context.Context, prompt string) (string, error) {
-	client, _ := genai.NewClient(ctx, &genai.ClientConfig{
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
 		APIKey:  config.EnvMap["GEMINI_AI_KEY"],
 		Backend: genai.BackendGeminiAPI,
 	})
+	if err != nil {
+		slog.Error("AI 클라이언트 생성 실패", "error", err)
+		return "", errors.New("AI 클라이언트 생성 실패")
+	}
 
 	slog.Info(fmt.Sprintf(`프롬프트 요청 : %s`, prompt))
 
-	result, _ := client.Models.GenerateContent(ctx, "gemini-2.0-flash-preview-image-generation", genai.Text(prompt), &genai.GenerateContentConfig{
+	result, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash-preview-image-generation", genai.Text(prompt), &genai.GenerateContentConfig{
 		ResponseModalities: []string{"Text", "Image"},
 	})
+	if err != nil {
+		slog.Error("이미지 생성 요청 실패", "error", err)
+		return "", errors.New("이미지 생성 실패")
+	}
 	slog.Info("이미지 생성 응답", "결과", result)
 
 	for _, part := range result.Candidates[0].Content.Parts {

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log/slog"
 	resources "simple-server"
 
 	"github.com/joho/godotenv"
@@ -9,8 +10,19 @@ import (
 var EnvMap map[string]string
 
 func LoadEnv() {
-	envData, _ := resources.EmbeddedFiles.ReadFile(".env")
-	EnvMap, _ = godotenv.Unmarshal(string(envData))
+	envData, err := resources.EmbeddedFiles.ReadFile(".env")
+	if err != nil {
+		slog.Error("환경 파일 읽기 실패", "error", err)
+		return
+	}
+
+	envMap, err := godotenv.Unmarshal(string(envData))
+	if err != nil {
+		slog.Error("환경 변수 파싱 실패", "error", err)
+		return
+	}
+
+	EnvMap = envMap
 }
 
 func IsDevEnv() bool {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -99,7 +99,11 @@ func RegisterFirebaseAuthMiddleware(e *echo.Echo, ensureUserFn func(ctx context.
 
 /* 권한 */
 func InitCasbin() error {
-	db, _ := connection.AppDBOpen()
+	db, err := connection.AppDBOpen()
+	if err != nil {
+		slog.Error("데이터베이스 연결 실패", "error", err)
+		return err
+	}
 	adapter, err := sqladapter.NewAdapter(db, "sqlite", "")
 	if err != nil {
 		slog.Error("casbin adapter 초기화 실패", "error", err.Error())

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 	resources "simple-server"
@@ -21,8 +22,17 @@ func RegisterCommonMiddleware(e *echo.Echo) error {
 	var projectStaticFS fs.FS
 	projectStaticDir := fmt.Sprintf("projects/%s/static", serviceName)
 	if config.IsProdEnv() {
-		sharedStaticFS, _ = fs.Sub(resources.EmbeddedFiles, "shared/static")
-		projectStaticFS, _ = fs.Sub(resources.EmbeddedFiles, projectStaticDir)
+		var err error
+		sharedStaticFS, err = fs.Sub(resources.EmbeddedFiles, "shared/static")
+		if err != nil {
+			slog.Error("정적 파일 시스템 초기화 실패", "error", err)
+			return err
+		}
+		projectStaticFS, err = fs.Sub(resources.EmbeddedFiles, projectStaticDir)
+		if err != nil {
+			slog.Error("프로젝트 정적 파일 시스템 초기화 실패", "error", err)
+			return err
+		}
 	} else {
 		sharedStaticFS = os.DirFS("shared/static")
 		projectStaticFS = os.DirFS(projectStaticDir)

--- a/pkg/util/dateutil/date.go
+++ b/pkg/util/dateutil/date.go
@@ -512,7 +512,10 @@ func GetLastDayOfWeek(dateStr string) (string, error) {
 		return "", err
 	}
 
-	firstDate, _ := time.Parse(DateFormatYYYYMMDD, firstDay)
+	firstDate, err := time.Parse(DateFormatYYYYMMDD, firstDay)
+	if err != nil {
+		return "", fmt.Errorf("날짜 파싱 오류: %w", err)
+	}
 	sunday := firstDate.AddDate(0, 0, 6) // 월요일부터 6일 후는 일요일
 
 	return sunday.Format(DateFormatYYYYMMDD), nil

--- a/pkg/util/stringutil/string.go
+++ b/pkg/util/stringutil/string.go
@@ -493,7 +493,10 @@ func HasSpecialChar(s string) bool {
 //	isValid := util.IsValidEmail("example@example.com")
 func IsValidEmail(email string) bool {
 	pattern := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
-	match, _ := regexp.MatchString(pattern, email)
+	match, err := regexp.MatchString(pattern, email)
+	if err != nil {
+		return false
+	}
 	return match
 }
 
@@ -509,7 +512,10 @@ func IsValidKoreanPhoneNumber(phone string) bool {
 
 	// 한국 휴대폰 번호 패턴 검사 (01X-XXXX-XXXX)
 	pattern := `^01[0-9][0-9]{7,8}$`
-	match, _ := regexp.MatchString(pattern, phone)
+	match, err := regexp.MatchString(pattern, phone)
+	if err != nil {
+		return false
+	}
 	return match
 }
 

--- a/projects/deario/services/users.go
+++ b/projects/deario/services/users.go
@@ -13,9 +13,13 @@ import (
 func EnsureUser(ctx context.Context, uid string) error {
 	slog.Info("EnsureUser called", "uid", uid)
 
-	queries, _ := db.GetQueries(ctx)
+	queries, err := db.GetQueries(ctx)
+	if err != nil {
+		slog.Error("쿼리 로드 실패", "error", err)
+		return err
+	}
 
-	_, err := queries.GetUser(ctx, uid)
+	_, err = queries.GetUser(ctx, uid)
 	if err != nil {
 		slog.Info("User not found in database, creating new user", "uid", uid, "error", err)
 

--- a/projects/sample/handlers/study.go
+++ b/projects/sample/handlers/study.go
@@ -14,10 +14,14 @@ import (
 func AIStudy(c echo.Context, random bool) error {
 	ctx := c.Request().Context()
 	input := c.Request().FormValue("input")
-	client, _ := genai.NewClient(ctx, &genai.ClientConfig{
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
 		APIKey:  config.EnvMap["GEMINI_AI_KEY"],
 		Backend: genai.BackendGeminiAPI,
 	})
+	if err != nil {
+		slog.Error("AI 클라이언트 생성 실패", "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "AI 초기화 실패")
+	}
 
 	if random {
 		input = "너가 정해줘"

--- a/projects/sample/jobs/squash.go
+++ b/projects/sample/jobs/squash.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"log/slog"
 	"simple-server/internal/config"
 
 	"github.com/go-rod/rod"
@@ -9,7 +10,9 @@ import (
 )
 
 func SquashJob(c *cron.Cron) {
-	_, _ = c.AddFunc("* * * * *", SquashExecute)
+	if _, err := c.AddFunc("* * * * *", SquashExecute); err != nil {
+		slog.Error("스케줄 등록 실패", "error", err)
+	}
 }
 
 func SquashExecute() {


### PR DESCRIPTION
## Summary
- avoid swallowing errors in multiple modules
- add Korean slog messages
- handle logging DB initialization issues
- include error checks for push scheduling and AI client

## Testing
- `go test ./...`
- `golangci-lint run ./...`
- `bash error-check.sh` *(fails: `proxy.golang.org` access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685264e8d4a0832faf0f16a0b974c5e7