### PR TITLE
Add custom error handler

### DIFF
--- a/internal/middleware/errorhandler.go
+++ b/internal/middleware/errorhandler.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// RegisterErrorHandler : 에코 전역 에러 핸들러 등록
+func RegisterErrorHandler(e *echo.Echo) {
+	e.HTTPErrorHandler = func(err error, c echo.Context) {
+		var (
+			code    int
+			message string
+		)
+
+		if he, ok := err.(*echo.HTTPError); ok {
+			code = he.Code
+			if m, ok := he.Message.(string); ok {
+				message = m
+			} else {
+				message = fmt.Sprint(he.Message)
+			}
+		} else {
+			code = http.StatusInternalServerError
+			message = http.StatusText(code)
+		}
+
+		slog.Error("요청 처리 실패",
+			"error", err,
+			"status", code,
+			"method", c.Request().Method,
+			"path", c.Path(),
+		)
+
+		if !c.Response().Committed {
+			if c.Request().Method == http.MethodHead {
+				_ = c.NoContent(code)
+			} else {
+				_ = c.String(code, message)
+			}
+		}
+	}
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -16,6 +16,8 @@ import (
 )
 
 func RegisterCommonMiddleware(e *echo.Echo) error {
+	RegisterErrorHandler(e)
+
 	serviceName := os.Getenv("SERVICE_NAME")
 
 	var sharedStaticFS fs.FS


### PR DESCRIPTION
## Summary
- handle all errors in one place with slog and consistent responses
- hook the new handler into the common middleware

## Testing
- `go build ./...` *(fails: proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68577e9cc954832f928284e4a023bf32