### PR TITLE
Move logging DB wrapper to internal

### DIFF
--- a/internal/connection/loggingdb.go
+++ b/internal/connection/loggingdb.go
@@ -1,0 +1,47 @@
+package connection
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+)
+
+type LoggingDB struct {
+	*sql.DB
+}
+
+func (ldb *LoggingDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	slog.Debug("쿼리 Exec", "query", query, "args", args)
+	res, err := ldb.DB.ExecContext(ctx, query, args...)
+	if err != nil {
+		slog.Debug("쿼리 Exec 실패", "error", err)
+		return res, err
+	}
+	if rows, err := res.RowsAffected(); err == nil {
+		slog.Debug("쿼리 Exec 성공", "rows", rows)
+	}
+	return res, nil
+}
+
+func (ldb *LoggingDB) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	slog.Debug("쿼리 Prepare", "query", query)
+	stmt, err := ldb.DB.PrepareContext(ctx, query)
+	if err != nil {
+		slog.Debug("쿼리 Prepare 실패", "error", err)
+	}
+	return stmt, err
+}
+
+func (ldb *LoggingDB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	slog.Debug("쿼리 Query", "query", query, "args", args)
+	rows, err := ldb.DB.QueryContext(ctx, query, args...)
+	if err != nil {
+		slog.Debug("쿼리 Query 실패", "error", err)
+	}
+	return rows, err
+}
+
+func (ldb *LoggingDB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	slog.Debug("쿼리 QueryRow", "query", query, "args", args)
+	return ldb.DB.QueryRowContext(ctx, query, args...)
+}

--- a/projects/deario/db/util.go
+++ b/projects/deario/db/util.go
@@ -14,5 +14,6 @@ func GetQueries(ctx context.Context) (*Queries, error) {
 		return nil, err
 	}
 
-	return New(dbCon), nil
+	loggingDB := &connection.LoggingDB{DB: dbCon}
+	return New(loggingDB), nil
 }


### PR DESCRIPTION
## Summary
- move `LoggingDB` to `internal/connection`
- update `deario` DB util to use the shared wrapper

## Testing
- `bash error-check.sh build`
- `bash error-check.sh test`
- `bash error-check.sh lint` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857a9fcb158832f9ff2413e7ab32b89