### PR TITLE
Implement BeerCSS snackbars

### DIFF
--- a/projects/ai-study/views/index.go
+++ b/projects/ai-study/views/index.go
@@ -19,6 +19,7 @@ func Index(title string) Node {
 		Language: "ko",
 		Head:     shared.HeadsWithBulma(title),
 		Body: []Node{
+			shared.Snackbar(),
 			b.Container(b.MaxTablet, b.Padding(2),
 				b.Columns(
 					b.Column(
@@ -86,7 +87,7 @@ func Index(title string) Node {
 				document.getElementById("copy").addEventListener("click", () => {
 					navigator.clipboard.writeText(
 						document.getElementById("result").innerText
-					).then(() => alert("복사 되었습니다."));
+                                        ).then(() => showInfo("복사 되었습니다."));
 				});
 			`)),
 		},

--- a/projects/deario/views/index.go
+++ b/projects/deario/views/index.go
@@ -28,6 +28,7 @@ func Index(title string, date string) Node {
 			},
 		),
 		Body: []Node{
+			shared.Snackbar(),
 			/* Header */
 			Header(Class("fixed yellow4"),
 				Nav(
@@ -182,7 +183,7 @@ func Index(title string, date string) Node {
 						Button(Class("border"),
 							h.Post("/ai-feedback/save?"),
 							h.Swap("none"),
-							h.On("htmx:after-on-load", "if (event.detail.successful) alert('저장 되었습니다.')"),
+							h.On("htmx:after-on-load", "if (event.detail.successful) showInfo('저장 되었습니다.')"),
 							I(Text("save")),
 							Span(Text("저장")),
 						),

--- a/shared/static/app.js
+++ b/shared/static/app.js
@@ -16,7 +16,30 @@ document.addEventListener("alpine:init", () => {
   Alpine.store("notification", {
     permission: Notification.permission === "granted",
   });
+
+  Alpine.store("snackbar", {
+    visible: false,
+    message: "",
+    type: "primary",
+    show(msg, type = "primary", ms = 3000) {
+      this.message = msg;
+      this.type = type;
+      this.visible = true;
+      setTimeout(() => {
+        this.visible = false;
+      }, ms);
+    },
+    info(msg, ms) {
+      this.show(msg, "primary", ms);
+    },
+    error(msg, ms) {
+      this.show(msg, "error", ms);
+    },
+  });
 });
+
+window.showInfo = (msg, ms) => Alpine.store("snackbar").info(msg, ms);
+window.showError = (msg, ms) => Alpine.store("snackbar").error(msg, ms);
 
 htmx.on("htmx:afterRequest", (event) => {
   const contentType = event.detail.xhr.getResponseHeader("Content-Type");
@@ -35,7 +58,7 @@ htmx.on("htmx:afterRequest", (event) => {
     if (parsedResponse.message === undefined || parsedResponse.message === "") {
       return;
     }
-    alert(parsedResponse.message);
+    showError(parsedResponse.message);
   }
 });
 

--- a/shared/static/firebase_auth.js
+++ b/shared/static/firebase_auth.js
@@ -87,7 +87,7 @@ htmx.on("htmx:afterRequest", (event) => {
           if (response.ok) {
             location.reload();
           } else {
-            alert("재 로그인 실패");
+            showError("재 로그인 실패");
           }
         })
         .catch((err) => {

--- a/shared/static/firebase_login.js
+++ b/shared/static/firebase_login.js
@@ -37,7 +37,7 @@ const uiConfig = {
           if (response.ok) {
             window.location.href = "/";
           } else {
-            alert("세션 생성 실패");
+            showError("세션 생성 실패");
           }
         })
         .catch((err) => {

--- a/shared/views/snackbar.go
+++ b/shared/views/snackbar.go
@@ -1,0 +1,17 @@
+package shared
+
+import (
+	x "github.com/glsubri/gomponents-alpine"
+	. "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/html"
+)
+
+func Snackbar() Node {
+	return Div(
+		x.Data("$store.snackbar"),
+		x.Show("visible"),
+		x.Class("`${type} ${visible ? 'active' : ''}`"),
+		Class("snackbar"),
+		Span(x.Text("message")),
+	)
+}


### PR DESCRIPTION
## Summary
- create reusable snackbar view component
- add Alpine snackbar store and helper functions
- use snackbars in AI Study and Deario index views
- replace alert() calls in frontend scripts

## Testing
- `bash ./error-check.sh` *(fails: proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686b95721000832f88a7024cb26f1084