### PR TITLE
Update statistics limit and mood labels

### DIFF
--- a/projects/deario/db/query.sql.go
+++ b/projects/deario/db/query.sql.go
@@ -257,11 +257,15 @@ func (q *Queries) ListPushTargets(ctx context.Context) ([]ListPushTargetsRow, er
 }
 
 const monthlyDiaryCount = `-- name: MonthlyDiaryCount :many
-SELECT substr(date, 1, 6) AS month, COUNT(*) AS count
-FROM diary
-WHERE uid = ?
-GROUP BY substr(date, 1, 6)
-ORDER BY month
+WITH monthly AS (
+    SELECT substr(date, 1, 6) AS month, COUNT(*) AS count
+    FROM diary
+    WHERE uid = ?
+    GROUP BY substr(date, 1, 6)
+    ORDER BY month DESC
+    LIMIT 6
+)
+SELECT month, count FROM monthly ORDER BY month
 `
 
 type MonthlyDiaryCountRow struct {
@@ -293,11 +297,15 @@ func (q *Queries) MonthlyDiaryCount(ctx context.Context, uid string) ([]MonthlyD
 }
 
 const monthlyMoodAvg = `-- name: MonthlyMoodAvg :many
-SELECT substr(date, 1, 6) AS month, AVG(CAST(mood AS INTEGER)) AS mood_avg
-FROM diary
-WHERE uid = ?
-GROUP BY substr(date, 1, 6)
-ORDER BY month
+WITH monthly AS (
+    SELECT substr(date, 1, 6) AS month, AVG(CAST(mood AS INTEGER)) AS mood_avg
+    FROM diary
+    WHERE uid = ?
+    GROUP BY substr(date, 1, 6)
+    ORDER BY month DESC
+    LIMIT 6
+)
+SELECT month, mood_avg FROM monthly ORDER BY month
 `
 
 type MonthlyMoodAvgRow struct {
@@ -329,17 +337,21 @@ func (q *Queries) MonthlyMoodAvg(ctx context.Context, uid string) ([]MonthlyMood
 }
 
 const monthlyMoodCount = `-- name: MonthlyMoodCount :many
-SELECT
-    substr(date, 1, 6) AS month,
-    sum(CASE WHEN mood='1' THEN 1 ELSE 0 END) AS mood1,
-    sum(CASE WHEN mood='2' THEN 1 ELSE 0 END) AS mood2,
-    sum(CASE WHEN mood='3' THEN 1 ELSE 0 END) AS mood3,
-    sum(CASE WHEN mood='4' THEN 1 ELSE 0 END) AS mood4,
-    sum(CASE WHEN mood='5' THEN 1 ELSE 0 END) AS mood5
-FROM diary
-WHERE uid = ?
-GROUP BY substr(date, 1, 6)
-ORDER BY month
+WITH monthly AS (
+    SELECT
+        substr(date, 1, 6) AS month,
+        sum(CASE WHEN mood='1' THEN 1 ELSE 0 END) AS mood1,
+        sum(CASE WHEN mood='2' THEN 1 ELSE 0 END) AS mood2,
+        sum(CASE WHEN mood='3' THEN 1 ELSE 0 END) AS mood3,
+        sum(CASE WHEN mood='4' THEN 1 ELSE 0 END) AS mood4,
+        sum(CASE WHEN mood='5' THEN 1 ELSE 0 END) AS mood5
+    FROM diary
+    WHERE uid = ?
+    GROUP BY substr(date, 1, 6)
+    ORDER BY month DESC
+    LIMIT 6
+)
+SELECT month, mood1, mood2, mood3, mood4, mood5 FROM monthly ORDER BY month
 `
 
 type MonthlyMoodCountRow struct {

--- a/projects/deario/query.sql
+++ b/projects/deario/query.sql
@@ -103,28 +103,40 @@ SELECT * FROM user WHERE uid = ? LIMIT 1;
 -- name: CreateUser :exec
 INSERT INTO user (uid, name, email) VALUES (?, ?, ?);
 -- name: MonthlyDiaryCount :many
-SELECT substr(date, 1, 6) AS month, COUNT(*) AS count
-FROM diary
-WHERE uid = ?
-GROUP BY substr(date, 1, 6)
-ORDER BY month;
+WITH monthly AS (
+    SELECT substr(date, 1, 6) AS month, COUNT(*) AS count
+    FROM diary
+    WHERE uid = ?
+    GROUP BY substr(date, 1, 6)
+    ORDER BY month DESC
+    LIMIT 6
+)
+SELECT * FROM monthly ORDER BY month;
 
 -- name: MonthlyMoodAvg :many
-SELECT substr(date, 1, 6) AS month, AVG(CAST(mood AS INTEGER)) AS mood_avg
-FROM diary
-WHERE uid = ?
-GROUP BY substr(date, 1, 6)
-ORDER BY month;
+WITH monthly AS (
+    SELECT substr(date, 1, 6) AS month, AVG(CAST(mood AS INTEGER)) AS mood_avg
+    FROM diary
+    WHERE uid = ?
+    GROUP BY substr(date, 1, 6)
+    ORDER BY month DESC
+    LIMIT 6
+)
+SELECT * FROM monthly ORDER BY month;
 
 -- name: MonthlyMoodCount :many
-SELECT
-    substr(date, 1, 6) AS month,
-    sum(CASE WHEN mood='1' THEN 1 ELSE 0 END) AS mood1,
-    sum(CASE WHEN mood='2' THEN 1 ELSE 0 END) AS mood2,
-    sum(CASE WHEN mood='3' THEN 1 ELSE 0 END) AS mood3,
-    sum(CASE WHEN mood='4' THEN 1 ELSE 0 END) AS mood4,
-    sum(CASE WHEN mood='5' THEN 1 ELSE 0 END) AS mood5
-FROM diary
-WHERE uid = ?
-GROUP BY substr(date, 1, 6)
-ORDER BY month;
+WITH monthly AS (
+    SELECT
+        substr(date, 1, 6) AS month,
+        sum(CASE WHEN mood='1' THEN 1 ELSE 0 END) AS mood1,
+        sum(CASE WHEN mood='2' THEN 1 ELSE 0 END) AS mood2,
+        sum(CASE WHEN mood='3' THEN 1 ELSE 0 END) AS mood3,
+        sum(CASE WHEN mood='4' THEN 1 ELSE 0 END) AS mood4,
+        sum(CASE WHEN mood='5' THEN 1 ELSE 0 END) AS mood5
+    FROM diary
+    WHERE uid = ?
+    GROUP BY substr(date, 1, 6)
+    ORDER BY month DESC
+    LIMIT 6
+)
+SELECT * FROM monthly ORDER BY month;

--- a/projects/deario/static/statistic.js
+++ b/projects/deario/static/statistic.js
@@ -1,5 +1,7 @@
 console.log("statistic page loaded");
 
+const moodIcons = ["", "😁", "🙂", "😐", "😣", "😭"];
+
 document.addEventListener("DOMContentLoaded", () => {
   fetch("/statistic/data")
     .then((res) => res.json())
@@ -46,11 +48,31 @@ document.addEventListener("DOMContentLoaded", () => {
         data: {
           labels: data.months,
           datasets: [
-            { label: "1", data: data.mood1, backgroundColor: "#ffeb3b" },
-            { label: "2", data: data.mood2, backgroundColor: "#8bc34a" },
-            { label: "3", data: data.mood3, backgroundColor: "#03a9f4" },
-            { label: "4", data: data.mood4, backgroundColor: "#ff9800" },
-            { label: "5", data: data.mood5, backgroundColor: "#f44336" },
+            {
+              label: `1 ${moodIcons[1]}`,
+              data: data.mood1,
+              backgroundColor: "#ffeb3b",
+            },
+            {
+              label: `2 ${moodIcons[2]}`,
+              data: data.mood2,
+              backgroundColor: "#8bc34a",
+            },
+            {
+              label: `3 ${moodIcons[3]}`,
+              data: data.mood3,
+              backgroundColor: "#03a9f4",
+            },
+            {
+              label: `4 ${moodIcons[4]}`,
+              data: data.mood4,
+              backgroundColor: "#ff9800",
+            },
+            {
+              label: `5 ${moodIcons[5]}`,
+              data: data.mood5,
+              backgroundColor: "#f44336",
+            },
           ],
         },
         options: {


### PR DESCRIPTION
## Summary
- limit statistics queries to last 6 months
- show mood icons in statistics stacked bar chart

## Testing
- `bash error-check.sh` *(fails: proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6878c3bddb50832fa8072e106ee4a2af