### PR TITLE
Implement localStorage auth persistence

### DIFF
--- a/shared/static/app.js
+++ b/shared/static/app.js
@@ -6,12 +6,28 @@ document.addEventListener("alpine:init", () => {
     login(user) {
       this.isAuthed = true;
       this.user = user;
+      try {
+        localStorage.setItem("authUser", JSON.stringify(user));
+      } catch (e) {
+        console.error("localStorage save error", e);
+      }
     },
     logout() {
       this.isAuthed = false;
       this.user = null;
+      localStorage.removeItem("authUser");
     },
   });
+
+  const saved = localStorage.getItem("authUser");
+  if (saved) {
+    try {
+      Alpine.store("auth").login(JSON.parse(saved));
+    } catch (e) {
+      console.error("localStorage parse error", e);
+      localStorage.removeItem("authUser");
+    }
+  }
 
   Alpine.store("notification", {
     permission: Notification.permission === "granted",


### PR DESCRIPTION
## Summary
- persist user info in localStorage
- restore auth state on page load

## Testing
- `sh error-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687df72420fc832f969415d00473af9e