### PR TITLE
Add CSRF token helper

### DIFF
--- a/pkg/util/gomutil/csrf.go
+++ b/pkg/util/gomutil/csrf.go
@@ -1,0 +1,11 @@
+package gomutil
+
+import (
+	. "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/html"
+)
+
+// CSRFInput returns a hidden input element with the given CSRF token.
+func CSRFInput(token string) Node {
+	return Input(Type("hidden"), Name("csrf"), Value(token))
+}

--- a/pkg/util/gomutil/csrf_test.go
+++ b/pkg/util/gomutil/csrf_test.go
@@ -1,0 +1,14 @@
+package gomutil
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCSRFInput(t *testing.T) {
+	result := fmt.Sprint(CSRFInput("token"))
+	expected := `<input type="hidden" name="csrf" value="token">`
+	if result != expected {
+		t.Errorf("got %s, want %s", result, expected)
+	}
+}

--- a/projects/deario/handlers/deario.go
+++ b/projects/deario/handlers/deario.go
@@ -50,7 +50,8 @@ func Index(c echo.Context) error {
 	}
 
 	if isPinRequired(userSetting) {
-		return views.Pin().Render(c.Response().Writer)
+		token, _ := c.Get("csrf").(string)
+		return views.Pin(token).Render(c.Response().Writer)
 	}
 
 	diary, err := queries.GetDiary(c.Request().Context(), db.GetDiaryParams{

--- a/projects/deario/views/pin.go
+++ b/projects/deario/views/pin.go
@@ -10,7 +10,7 @@ import (
 	. "maragu.dev/gomponents/html"
 )
 
-func Pin() Node {
+func Pin(csrfToken string) Node {
 	return HTML5(HTML5Props{
 		Title:    "핀 입력",
 		Language: "ko",
@@ -27,6 +27,7 @@ func Pin() Node {
 			layout.AppHeader(),
 			Main(Class("responsive"),
 				Form(Action("/pin"), Method("POST"),
+					gomutil.CSRFInput(csrfToken),
 					FieldSet(
 						Legend(Text("핀 번호 입력")),
 						Div(Class("field border label"),


### PR DESCRIPTION
## Summary
- create `CSRFInput` helper for gomponents
- fix PIN form to embed CSRF token
- pass token from handler
- add unit test for helper

## Testing
- `bash ./error-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e14691e94832fbf52825c8bfe88f8