### PR TITLE
Update pin verification to use HTMX

### DIFF
--- a/projects/deario/handlers/deario.go
+++ b/projects/deario/handlers/deario.go
@@ -49,10 +49,9 @@ func Index(c echo.Context) error {
 		return err
 	}
 
-	if isPinRequired(userSetting) {
-		token, _ := c.Get("csrf").(string)
-		return views.Pin(token).Render(c.Response().Writer)
-	}
+        if isPinRequired(userSetting) {
+                return views.Pin().Render(c.Response().Writer)
+        }
 
 	diary, err := queries.GetDiary(c.Request().Context(), db.GetDiaryParams{
 		Uid:  uid,
@@ -627,9 +626,9 @@ func PinCheck(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "핀번호가 일치하지 않습니다")
 	}
 
-	if err := queries.UpdatePinLastAt(c.Request().Context(), uid); err != nil {
-		return err
-	}
+        if err := queries.UpdatePinLastAt(c.Request().Context(), uid); err != nil {
+                return err
+        }
 
-	return c.Redirect(http.StatusSeeOther, "/")
+        return c.HTML(http.StatusOK, "<script>location.href = \"/\";</script>")
 }

--- a/projects/deario/views/pin.go
+++ b/projects/deario/views/pin.go
@@ -1,16 +1,18 @@
 package views
 
 import (
-	"simple-server/pkg/util/gomutil"
-	"simple-server/projects/deario/views/layout"
-	shared "simple-server/shared/views"
+        "simple-server/pkg/util/gomutil"
+        "simple-server/projects/deario/views/layout"
+        shared "simple-server/shared/views"
 
-	. "maragu.dev/gomponents"
-	. "maragu.dev/gomponents/components"
-	. "maragu.dev/gomponents/html"
+        h "maragu.dev/gomponents-htmx"
+
+        . "maragu.dev/gomponents"
+        . "maragu.dev/gomponents/components"
+        . "maragu.dev/gomponents/html"
 )
 
-func Pin(csrfToken string) Node {
+func Pin() Node {
 	return HTML5(HTML5Props{
 		Title:    "핀 입력",
 		Language: "ko",
@@ -23,23 +25,22 @@ func Pin(csrfToken string) Node {
 			},
 		),
 		Body: []Node{
-			shared.Snackbar(),
-			layout.AppHeader(),
-			Main(Class("responsive"),
-				Form(Action("/pin"), Method("POST"),
-					gomutil.CSRFInput(csrfToken),
-					FieldSet(
-						Legend(Text("핀 번호 입력")),
-						Div(Class("field border label"),
-							Input(Type("password"), Name("pin"), AutoFocus()),
-							Label(Text("핀번호")),
-						),
-						Nav(Class("right-align"),
-							Button(Text("확인")),
-						),
-					),
-				),
-			),
+                        shared.Snackbar(),
+                        layout.AppHeader(),
+                        Main(Class("responsive"),
+                                Form(h.Post("/pin"), h.Target("this"), h.Swap("outerHTML"),
+                                        FieldSet(
+                                                Legend(Text("핀 번호 입력")),
+                                                Div(Class("field border label"),
+                                                        Input(Type("password"), Name("pin"), AutoFocus()),
+                                                        Label(Text("핀번호")),
+                                                ),
+                                                Nav(Class("right-align"),
+                                                        Button(Text("확인")),
+                                                ),
+                                        ),
+                                ),
+                        ),
 		},
 	})
 }


### PR DESCRIPTION
## Summary
- change pin input view to submit via HTMX
- drop CSRF hidden input since `app.js` adds the header
- return HTML script on success to redirect home

## Testing
- `go build ./...` *(fails: proxy access blocked)*
- `go test ./... -run TestCSRFInput -count=1` *(fails: proxy access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_687e19952c1c832f9114df390648196d