### PR TITLE
Add PIN reset feature via Firebase auth

### DIFF
--- a/cmd/deario/main.go
+++ b/cmd/deario/main.go
@@ -98,6 +98,7 @@ func setUpServer() *echo.Echo {
 	authGroup.GET("/setting", handlers.Setting)
 	authGroup.POST("/setting", handlers.SettingSave)
 	authGroup.POST("/pin", handlers.PinCheck)
+	authGroup.POST("/pin/reset", handlers.PinReset)
 	authGroup.POST("/diary/mood", handlers.UpdateDiaryOfMood)
 	authGroup.GET("/statistic", handlers.Statistic)
 	authGroup.GET("/statistic/data", handlers.StatisticData)

--- a/projects/deario/db/query.sql.go
+++ b/projects/deario/db/query.sql.go
@@ -392,6 +392,22 @@ func (q *Queries) MonthlyMoodCount(ctx context.Context, uid string) ([]MonthlyMo
 	return items, nil
 }
 
+const resetPin = `-- name: ResetPin :exec
+UPDATE user_setting
+SET
+    pin_enabled = 0,
+    pin = '',
+    pin_cycle = -1,
+    pin_last_at = '',
+    updated = datetime('now')
+WHERE uid = ?
+`
+
+func (q *Queries) ResetPin(ctx context.Context, uid string) error {
+	_, err := q.db.ExecContext(ctx, resetPin, uid)
+	return err
+}
+
 const updateDiary = `-- name: UpdateDiary :one
 UPDATE diary
 SET

--- a/projects/deario/query.sql
+++ b/projects/deario/query.sql
@@ -126,6 +126,16 @@ SELECT *
 FROM monthly
 ORDER BY month;
 
+-- name: ResetPin :exec
+UPDATE user_setting
+SET
+    pin_enabled = 0,
+    pin = '',
+    pin_cycle = -1,
+    pin_last_at = '',
+    updated = datetime('now')
+WHERE uid = ?;
+
 -- name: UpdatePinLastAt :exec
 UPDATE user_setting
 SET

--- a/projects/deario/static/deario.js
+++ b/projects/deario/static/deario.js
@@ -13,3 +13,25 @@ document.addEventListener("alpine:init", () => {
     },
   });
 });
+
+window.resetPin = async function () {
+  try {
+    const token = await window.getIdToken();
+    const res = await fetch("/pin/reset", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": getCookie("_csrf"),
+      },
+      body: JSON.stringify({ token }),
+    });
+    if (res.ok) {
+      showInfo("핀번호가 초기화되었습니다.");
+      location.reload();
+    } else {
+      showError("핀번호 초기화 실패");
+    }
+  } catch (e) {
+    showError("재인증 실패");
+  }
+};

--- a/projects/deario/views/pin.go
+++ b/projects/deario/views/pin.go
@@ -37,6 +37,7 @@ func Pin() Node {
 						),
 						Nav(Class("right-align"),
 							Button(Text("확인")),
+							Button(Type("button"), Attr("onclick", "resetPin()"), Class("secondary"), Text("핀 초기화")),
 						),
 					),
 				),

--- a/shared/static/firebase_auth.js
+++ b/shared/static/firebase_auth.js
@@ -22,6 +22,14 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const messaging = getMessaging(app);
 
+window.getIdToken = async function () {
+  await auth.authStateReady();
+  if (auth.currentUser === undefined) {
+    throw new Error("no user");
+  }
+  return await auth.currentUser.getIdToken(true);
+};
+
 window.logoutUser = async function () {
   try {
     await signOut(auth);


### PR DESCRIPTION
## Summary
- add global `getIdToken` helper for Firebase auth
- implement PIN reset logic in deario handlers and queries
- expose `resetPin` JS function and button in the PIN page
- register `POST /pin/reset` route

## Testing
- `bash error-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e2322bd18832fb42aab079c3de50c