### PR TITLE
Add sessionStorage pin check

### DIFF
--- a/projects/deario/handlers/deario.go
+++ b/projects/deario/handlers/deario.go
@@ -654,7 +654,7 @@ func PinCheck(c echo.Context) error {
 		return err
 	}
 
-	return c.HTML(http.StatusOK, "<script>location.href = \"/\";</script>")
+	return c.HTML(http.StatusOK, "<script>pinChecked();location.href = \"/\";</script>")
 }
 
 func PinReset(c echo.Context) error {

--- a/projects/deario/static/deario.js
+++ b/projects/deario/static/deario.js
@@ -14,6 +14,10 @@ document.addEventListener("alpine:init", () => {
   });
 });
 
+window.pinChecked = function () {
+  sessionStorage.setItem("pinChecked", "true");
+};
+
 window.resetPin = async function () {
   try {
     const token = await window.getIdToken();

--- a/projects/deario/static/pin_check.js
+++ b/projects/deario/static/pin_check.js
@@ -1,0 +1,3 @@
+if (!sessionStorage.getItem('pinChecked')) {
+  location.href = '/pin';
+}

--- a/projects/deario/views/index.go
+++ b/projects/deario/views/index.go
@@ -26,6 +26,7 @@ func Index(title string, date string, mood string) Node {
 			[]Node{
 				Link(Rel("manifest"), Href("/manifest.json")),
 				Script(Src("/static/deario.js")),
+				Script(Src("/static/pin_check.js")),
 			},
 		),
 		Body: []Node{


### PR DESCRIPTION
## Summary
- set `pinChecked` flag on PIN check success
- add script to redirect to `/pin` if `pinChecked` missing

## Testing
- `bash ./error-check.sh` *(fails: could not run golangci-lint due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687edf95b370832f8f1c9e898af148bf