### PR TITLE
Add theme setting to deario

### DIFF
--- a/projects/deario/db/models.go
+++ b/projects/deario/db/models.go
@@ -36,4 +36,5 @@ type UserSetting struct {
 	RandomRange int64
 	Created     sql.NullString
 	Updated     sql.NullString
+	Theme       string
 }

--- a/projects/deario/db/query.sql.go
+++ b/projects/deario/db/query.sql.go
@@ -142,7 +142,7 @@ func (q *Queries) GetUser(ctx context.Context, uid string) (User, error) {
 }
 
 const getUserSetting = `-- name: GetUserSetting :one
-SELECT uid, is_push, push_token, push_time, random_range, created, updated FROM user_setting WHERE uid = ? LIMIT 1
+SELECT uid, is_push, push_token, push_time, random_range, created, updated, theme FROM user_setting WHERE uid = ? LIMIT 1
 `
 
 func (q *Queries) GetUserSetting(ctx context.Context, uid string) (UserSetting, error) {
@@ -156,6 +156,7 @@ func (q *Queries) GetUserSetting(ctx context.Context, uid string) (UserSetting, 
 		&i.RandomRange,
 		&i.Created,
 		&i.Updated,
+		&i.Theme,
 	)
 	return i, err
 }
@@ -486,15 +487,17 @@ INSERT INTO
         uid,
         is_push,
         push_time,
-        random_range
+        random_range,
+        theme
     )
-VALUES (?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?)
 ON CONFLICT (uid) DO
 UPDATE
 SET
     is_push = excluded.is_push,
     push_time = excluded.push_time,
     random_range = excluded.random_range,
+    theme = excluded.theme,
     updated = datetime('now')
 `
 
@@ -503,6 +506,7 @@ type UpsertUserSettingParams struct {
 	IsPush      int64
 	PushTime    string
 	RandomRange int64
+	Theme       string
 }
 
 func (q *Queries) UpsertUserSetting(ctx context.Context, arg UpsertUserSettingParams) error {
@@ -511,6 +515,7 @@ func (q *Queries) UpsertUserSetting(ctx context.Context, arg UpsertUserSettingPa
 		arg.IsPush,
 		arg.PushTime,
 		arg.RandomRange,
+		arg.Theme,
 	)
 	return err
 }

--- a/projects/deario/migrations/005_user_setting_theme.sql
+++ b/projects/deario/migrations/005_user_setting_theme.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+ALTER TABLE user_setting
+ADD COLUMN theme TEXT DEFAULT 'light' NOT NULL CHECK (theme IN ('light', 'dark'));
+
+-- +goose Down
+ALTER TABLE user_setting DROP COLUMN theme;

--- a/projects/deario/query.sql
+++ b/projects/deario/query.sql
@@ -64,15 +64,17 @@ INSERT INTO
         uid,
         is_push,
         push_time,
-        random_range
+        random_range,
+        theme
     )
-VALUES (?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?)
 ON CONFLICT (uid) DO
 UPDATE
 SET
     is_push = excluded.is_push,
     push_time = excluded.push_time,
     random_range = excluded.random_range,
+    theme = excluded.theme,
     updated = datetime('now');
 
 -- name: UpsertPushKey :exec

--- a/projects/deario/views/index.go
+++ b/projects/deario/views/index.go
@@ -16,7 +16,7 @@ import (
 	. "maragu.dev/gomponents/html"
 )
 
-func Index(title string, date string, mood string) Node {
+func Index(title string, date string, mood string, theme string) Node {
 	return HTML5(HTML5Props{
 		Title:    title,
 		Language: "ko",
@@ -28,6 +28,10 @@ func Index(title string, date string, mood string) Node {
 				Script(Src("/static/deario.js")),
 			},
 		),
+		HTMLAttrs: []Node{
+			Attr("data-theme", theme),
+			x.Init(fmt.Sprintf("Alpine.store('theme').set('%s')", theme)),
+		},
 		Body: []Node{
 			shared.Snackbar(),
 

--- a/projects/deario/views/setting.go
+++ b/projects/deario/views/setting.go
@@ -8,6 +8,7 @@ import (
 	"simple-server/projects/deario/views/layout"
 	shared "simple-server/shared/views"
 
+	x "github.com/glsubri/gomponents-alpine"
 	h "maragu.dev/gomponents-htmx"
 
 	. "maragu.dev/gomponents"
@@ -27,6 +28,10 @@ func Setting(userSetting db.UserSetting) Node {
 				Script(Src("/static/deario.js")),
 			},
 		),
+		HTMLAttrs: []Node{
+			Attr("data-theme", userSetting.Theme),
+			x.Init(fmt.Sprintf("Alpine.store('theme').set('%s')", userSetting.Theme)),
+		},
 		Body: []Node{
 			shared.Snackbar(),
 
@@ -57,6 +62,16 @@ func Setting(userSetting db.UserSetting) Node {
 							Input(Type("number"), Name("random_range"),
 								Value(fmt.Sprintf("%d", userSetting.RandomRange))),
 							Label(Text("랜덤일자")),
+						),
+						// 테마 설정
+						Div(x.Data(fmt.Sprintf("{ isDark: %t }", userSetting.Theme == "dark")),
+							Label(Class("switch"),
+								Input(Type("checkbox"), x.Model("isDark"),
+									Attr("@change", "Alpine.store('theme').set(isDark ? 'dark' : 'light')"),
+									If(userSetting.Theme == "dark", Checked())),
+								Span(Text("다크모드")),
+							),
+							Input(Type("hidden"), Name("theme"), x.Bind("value", "isDark ? 'dark' : 'light'")),
 						),
 						Nav(Class("right-align"),
 							Button(Text("저장")),

--- a/projects/deario/views/statistic.go
+++ b/projects/deario/views/statistic.go
@@ -1,16 +1,18 @@
 package views
 
 import (
+	"fmt"
 	"simple-server/pkg/util/gomutil"
 	"simple-server/projects/deario/views/layout"
 	shared "simple-server/shared/views"
 
+	x "github.com/glsubri/gomponents-alpine"
 	. "maragu.dev/gomponents"
 	. "maragu.dev/gomponents/components"
 	. "maragu.dev/gomponents/html"
 )
 
-func Statistic() Node {
+func Statistic(theme string) Node {
 	return HTML5(HTML5Props{
 		Title:    "통계",
 		Language: "ko",
@@ -23,6 +25,10 @@ func Statistic() Node {
 				Script(Src("/static/statistic.js")),
 			},
 		),
+		HTMLAttrs: []Node{
+			Attr("data-theme", theme),
+			x.Init(fmt.Sprintf("Alpine.store('theme').set('%s')", theme)),
+		},
 		Body: []Node{
 			shared.Snackbar(),
 			/* Header */

--- a/shared/static/app.js
+++ b/shared/static/app.js
@@ -52,6 +52,31 @@ document.addEventListener("alpine:init", () => {
       this.show(msg, "error", ms);
     },
   });
+
+  Alpine.store("theme", {
+    value: "light",
+    init() {
+      const saved = localStorage.getItem("theme");
+      if (saved) {
+        this.value = saved;
+      }
+      document.documentElement.setAttribute("data-theme", this.value);
+    },
+    set(theme) {
+      this.value = theme;
+      document.documentElement.setAttribute("data-theme", theme);
+      try {
+        localStorage.setItem("theme", theme);
+      } catch (e) {
+        console.error("localStorage save error", e);
+      }
+    },
+    toggle() {
+      this.set(this.value === "dark" ? "light" : "dark");
+    },
+  });
+
+  Alpine.store("theme").init();
 });
 
 htmx.on("htmx:afterRequest", (event) => {


### PR DESCRIPTION
## Summary
- support dark and light theme stored in user settings
- apply theme when rendering pages
- allow toggling theme in setting page
- persist theme choice in local storage via `app.js`
- include DB migration and sqlc updates

## Testing
- `bash error-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_688065a647e8832fafc51628c7bd609d