### PR TITLE
feat(deario): save diary image URLs from client uploads

### DIFF
--- a/cmd/deario/main.go
+++ b/cmd/deario/main.go
@@ -100,6 +100,8 @@ func setUpServer() *echo.Echo {
 	authGroup.POST("/diary/mood", handlers.UpdateDiaryOfMood)
 	authGroup.GET("/statistic", handlers.Statistic)
 	authGroup.GET("/statistic/data", handlers.StatisticData)
+	authGroup.GET("/diary/images", handlers.DiaryImages)
+	authGroup.POST("/diary/image", handlers.DiaryImageSave)
 	/* 권한 라우터 */
 
 	/* 큐 리시버 */

--- a/projects/deario/db/models.go
+++ b/projects/deario/db/models.go
@@ -18,6 +18,9 @@ type Diary struct {
 	Created    sql.NullString
 	Updated    sql.NullString
 	Mood       string
+	ImageUrl1  string
+	ImageUrl2  string
+	ImageUrl3  string
 }
 
 type Goqite struct {

--- a/projects/deario/db/query.sql.go
+++ b/projects/deario/db/query.sql.go
@@ -13,7 +13,7 @@ import (
 const createDiary = `-- name: CreateDiary :one
 INSERT INTO
     diary (uid, content, date)
-VALUES (?, ?, ?) RETURNING id, uid, date, content, ai_feedback, ai_image, created, updated, mood
+VALUES (?, ?, ?) RETURNING id, uid, date, content, ai_feedback, ai_image, created, updated, mood, image_url1, image_url2, image_url3
 `
 
 type CreateDiaryParams struct {
@@ -35,6 +35,9 @@ func (q *Queries) CreateDiary(ctx context.Context, arg CreateDiaryParams) (Diary
 		&i.Created,
 		&i.Updated,
 		&i.Mood,
+		&i.ImageUrl1,
+		&i.ImageUrl2,
+		&i.ImageUrl3,
 	)
 	return i, err
 }
@@ -65,7 +68,7 @@ func (q *Queries) DeleteDiary(ctx context.Context, id string) error {
 
 const getDiary = `-- name: GetDiary :one
 
-SELECT id, uid, date, content, ai_feedback, ai_image, created, updated, mood FROM diary WHERE date = ? AND uid = ? LIMIT 1
+SELECT id, uid, date, content, ai_feedback, ai_image, created, updated, mood, image_url1, image_url2, image_url3 FROM diary WHERE date = ? AND uid = ? LIMIT 1
 `
 
 type GetDiaryParams struct {
@@ -87,12 +90,15 @@ func (q *Queries) GetDiary(ctx context.Context, arg GetDiaryParams) (Diary, erro
 		&i.Created,
 		&i.Updated,
 		&i.Mood,
+		&i.ImageUrl1,
+		&i.ImageUrl2,
+		&i.ImageUrl3,
 	)
 	return i, err
 }
 
 const getDiaryRandom = `-- name: GetDiaryRandom :one
-SELECT id, uid, date, content, ai_feedback, ai_image, created, updated, mood
+SELECT id, uid, date, content, ai_feedback, ai_image, created, updated, mood, image_url1, image_url2, image_url3
 FROM diary
 WHERE
     date IS NOT NULL
@@ -120,6 +126,9 @@ func (q *Queries) GetDiaryRandom(ctx context.Context, arg GetDiaryRandomParams) 
 		&i.Created,
 		&i.Updated,
 		&i.Mood,
+		&i.ImageUrl1,
+		&i.ImageUrl2,
+		&i.ImageUrl3,
 	)
 	return i, err
 }
@@ -161,7 +170,7 @@ func (q *Queries) GetUserSetting(ctx context.Context, uid string) (UserSetting, 
 }
 
 const listDiarys = `-- name: ListDiarys :many
-SELECT id, uid, date, content, ai_feedback, ai_image, created, updated, mood
+SELECT id, uid, date, content, ai_feedback, ai_image, created, updated, mood, image_url1, image_url2, image_url3
 FROM diary
 WHERE
     uid = ?
@@ -194,6 +203,9 @@ func (q *Queries) ListDiarys(ctx context.Context, arg ListDiarysParams) ([]Diary
 			&i.Created,
 			&i.Updated,
 			&i.Mood,
+			&i.ImageUrl1,
+			&i.ImageUrl2,
+			&i.ImageUrl3,
 		); err != nil {
 			return nil, err
 		}
@@ -394,7 +406,7 @@ SET
     content = ?,
     updated = datetime('now')
 WHERE
-    id = ? RETURNING id, uid, date, content, ai_feedback, ai_image, created, updated, mood
+    id = ? RETURNING id, uid, date, content, ai_feedback, ai_image, created, updated, mood, image_url1, image_url2, image_url3
 `
 
 type UpdateDiaryParams struct {
@@ -415,8 +427,39 @@ func (q *Queries) UpdateDiary(ctx context.Context, arg UpdateDiaryParams) (Diary
 		&i.Created,
 		&i.Updated,
 		&i.Mood,
+		&i.ImageUrl1,
+		&i.ImageUrl2,
+		&i.ImageUrl3,
 	)
 	return i, err
+}
+
+const updateDiaryImages = `-- name: UpdateDiaryImages :exec
+UPDATE diary
+SET
+    image_url1 = ?,
+    image_url2 = ?,
+    image_url3 = ?,
+    updated = datetime('now')
+WHERE
+    id = ?
+`
+
+type UpdateDiaryImagesParams struct {
+	ImageUrl1 string
+	ImageUrl2 string
+	ImageUrl3 string
+	ID        string
+}
+
+func (q *Queries) UpdateDiaryImages(ctx context.Context, arg UpdateDiaryImagesParams) error {
+	_, err := q.db.ExecContext(ctx, updateDiaryImages,
+		arg.ImageUrl1,
+		arg.ImageUrl2,
+		arg.ImageUrl3,
+		arg.ID,
+	)
+	return err
 }
 
 const updateDiaryOfAiFeedback = `-- name: UpdateDiaryOfAiFeedback :exec

--- a/projects/deario/handlers/image.go
+++ b/projects/deario/handlers/image.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"simple-server/pkg/util/authutil"
+	"simple-server/projects/deario/db"
+	"simple-server/projects/deario/views"
+
+	"github.com/labstack/echo/v4"
+)
+
+func DiaryImages(c echo.Context) error {
+	uid, err := authutil.SessionUID(c)
+	if err != nil {
+		return err
+	}
+
+	date := c.QueryParam("date")
+	if date == "" {
+		date = time.Now().Format("20060102")
+	}
+	date = strings.ReplaceAll(date, "-", "")
+
+	queries, err := db.GetQueries(c.Request().Context())
+	if err != nil {
+		return err
+	}
+
+	diary, err := queries.GetDiary(c.Request().Context(), db.GetDiaryParams{
+		Uid:  uid,
+		Date: date,
+	})
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return views.DiaryImages("", "", "").Render(c.Response().Writer)
+	}
+
+	return views.DiaryImages(diary.ImageUrl1, diary.ImageUrl2, diary.ImageUrl3).Render(c.Response().Writer)
+}
+
+func DiaryImageSave(c echo.Context) error {
+	uid, err := authutil.SessionUID(c)
+	if err != nil {
+		return err
+	}
+
+	date := normalizeDate(c.FormValue("date"))
+	url := c.FormValue("url")
+	if url == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "URL이 필요합니다.")
+	}
+
+	queries, err := db.GetQueries(c.Request().Context())
+	if err != nil {
+		return err
+	}
+
+	diary, slot, err := diaryAndSlot(c.Request().Context(), queries, uid, date)
+	if err != nil {
+		return err
+	}
+
+	diary = setDiaryImage(diary, slot, url)
+	if err := queries.UpdateDiaryImages(c.Request().Context(), db.UpdateDiaryImagesParams{
+		ImageUrl1: diary.ImageUrl1,
+		ImageUrl2: diary.ImageUrl2,
+		ImageUrl3: diary.ImageUrl3,
+		ID:        diary.ID,
+	}); err != nil {
+		return err
+	}
+
+	return views.DiaryImages(diary.ImageUrl1, diary.ImageUrl2, diary.ImageUrl3).Render(c.Response().Writer)
+}
+
+func firstEmptyImageSlot(d db.Diary) (int, bool) {
+	slots := []string{d.ImageUrl1, d.ImageUrl2, d.ImageUrl3}
+	for i, v := range slots {
+		if v == "" {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func normalizeDate(d string) string {
+	if d == "" {
+		return time.Now().Format("20060102")
+	}
+	return strings.ReplaceAll(d, "-", "")
+}
+
+func diaryAndSlot(ctx context.Context, q *db.Queries, uid, date string) (db.Diary, int, error) {
+	diary, err := q.GetDiary(ctx, db.GetDiaryParams{Uid: uid, Date: date})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.Diary{}, -1, echo.NewHTTPError(http.StatusBadRequest, "일기를 먼저 작성해주세요.")
+		}
+		return db.Diary{}, -1, err
+	}
+	slot, ok := firstEmptyImageSlot(diary)
+	if !ok {
+		return db.Diary{}, -1, echo.NewHTTPError(http.StatusBadRequest, "이미지는 최대 3장까지 저장할 수 있습니다.")
+	}
+	return diary, slot, nil
+}
+
+func setDiaryImage(d db.Diary, slot int, url string) db.Diary {
+	switch slot {
+	case 0:
+		d.ImageUrl1 = url
+	case 1:
+		d.ImageUrl2 = url
+	case 2:
+		d.ImageUrl3 = url
+	}
+	return d
+}

--- a/projects/deario/migrations/008_diary_images.sql
+++ b/projects/deario/migrations/008_diary_images.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE diary ADD COLUMN image_url1 TEXT DEFAULT '' NOT NULL;
+ALTER TABLE diary ADD COLUMN image_url2 TEXT DEFAULT '' NOT NULL;
+ALTER TABLE diary ADD COLUMN image_url3 TEXT DEFAULT '' NOT NULL;
+
+-- +goose Down
+ALTER TABLE diary DROP COLUMN image_url1;
+ALTER TABLE diary DROP COLUMN image_url2;
+ALTER TABLE diary DROP COLUMN image_url3;

--- a/projects/deario/query.sql
+++ b/projects/deario/query.sql
@@ -55,6 +55,16 @@ SET
 WHERE
     id = ?;
 
+-- name: UpdateDiaryImages :exec
+UPDATE diary
+SET
+    image_url1 = ?,
+    image_url2 = ?,
+    image_url3 = ?,
+    updated = datetime('now')
+WHERE
+    id = ?;
+
 -- name: GetUserSetting :one
 SELECT * FROM user_setting WHERE uid = ? LIMIT 1;
 

--- a/projects/deario/static/firebase_storage.js
+++ b/projects/deario/static/firebase_storage.js
@@ -1,0 +1,37 @@
+import { getAuth } from "https://www.gstatic.com/firebasejs/11.0.2/firebase-auth.js";
+import {
+  getStorage,
+  ref,
+  uploadBytes,
+  getDownloadURL,
+} from "https://www.gstatic.com/firebasejs/11.0.2/firebase-storage.js";
+
+window.uploadDiaryImage = async function (date) {
+  const input = document.getElementById("diary-image-file");
+  if (!input || input.files.length === 0) {
+    return;
+  }
+
+  const auth = getAuth();
+  if (!auth.currentUser) {
+    showError("로그인이 필요합니다.");
+    return;
+  }
+
+  const file = input.files[0];
+  const storage = getStorage();
+  const path = `diary/${auth.currentUser.uid}/${date}_${Date.now()}`;
+
+  try {
+    const snapshot = await uploadBytes(ref(storage, path), file);
+    const url = await getDownloadURL(snapshot.ref);
+    htmx.ajax("POST", "/diary/image", {
+      target: "#diary-image-content",
+      swap: "outerHTML",
+      values: { date: date, url: url },
+    });
+  } catch (err) {
+    console.error("업로드 실패:", err);
+    showError("업로드 실패");
+  }
+};

--- a/projects/deario/static/firebase_storage.js
+++ b/projects/deario/static/firebase_storage.js
@@ -9,12 +9,13 @@ import {
 window.uploadDiaryImage = async function (date) {
   const input = document.getElementById("diary-image-file");
   if (!input || input.files.length === 0) {
+    alert("파일이 필요합니다.");
     return;
   }
 
   const auth = getAuth();
   if (!auth.currentUser) {
-    showError("로그인이 필요합니다.");
+    alert("로그인이 필요합니다.");
     return;
   }
 

--- a/projects/deario/views/diary_images.go
+++ b/projects/deario/views/diary_images.go
@@ -1,0 +1,21 @@
+package views
+
+import (
+	. "maragu.dev/gomponents"
+	. "maragu.dev/gomponents/html"
+)
+
+func DiaryImages(img1, img2, img3 string) Node {
+	nodes := []Node{}
+	urls := []string{img1, img2, img3}
+	for _, u := range urls {
+		if u != "" {
+			nodes = append(nodes, Img(Src(u), Class("responsive")))
+		}
+	}
+	if len(nodes) == 0 {
+		nodes = append(nodes, P(Text("이미지가 없습니다.")))
+	}
+	all := append([]Node{ID("diary-image-content")}, nodes...)
+	return Div(all...)
+}

--- a/projects/deario/views/index.go
+++ b/projects/deario/views/index.go
@@ -25,8 +25,8 @@ func Index(title string, date string, mood string) Node {
 			shared.HeadWithFirebaseAuth(),
 			[]Node{
 				Link(Rel("manifest"), Href("/manifest.json")),
-				Script(Type("module"), Src("/static/deario.js")),
-                                Script(Type("module"), Src("/static/firebase_storage.js")),
+				Script(Src("/static/deario.js")),
+				Script(Type("module"), Src("/static/firebase_storage.js")),
 			},
 		),
 		Body: []Node{
@@ -248,11 +248,13 @@ func Index(title string, date string, mood string) Node {
 					h.Get(fmt.Sprintf("/diary/images?date=%s", date)),
 					h.Trigger("load"),
 				),
-				Div(
+				Button(
+					I(Text("attach_file")),
+					Text("File"),
 					Input(Type("file"), ID("diary-image-file")),
-					Nav(Class("right-align"),
-						Button(Type("button"), Attr("onclick", fmt.Sprintf("uploadDiaryImage('%s')", date)), Text("업로드")),
-					),
+				),
+				Nav(Class("right-align"),
+					Button(Type("button"), Attr("onclick", fmt.Sprintf("uploadDiaryImage('%s')", date)), Text("업로드")),
 				),
 				Nav(Class("right-align"),
 					Button(Attr("data-ui", "#diary-image-dialog"), Text("닫기")),

--- a/projects/deario/views/index.go
+++ b/projects/deario/views/index.go
@@ -25,7 +25,8 @@ func Index(title string, date string, mood string) Node {
 			shared.HeadWithFirebaseAuth(),
 			[]Node{
 				Link(Rel("manifest"), Href("/manifest.json")),
-				Script(Src("/static/deario.js")),
+				Script(Type("module"), Src("/static/deario.js")),
+                                Script(Type("module"), Src("/static/firebase_storage.js")),
 			},
 		),
 		Body: []Node{
@@ -115,6 +116,9 @@ func Index(title string, date string, mood string) Node {
 					Button(Class("chip"), Attr("data-ui", "#cbt-dialog"),
 						I(Text("psychology_alt")),
 						Text("CBT"),
+					),
+					Button(Class("chip circle"), Attr("data-ui", "#diary-image-dialog"),
+						I(Text("image")),
 					),
 					Div(Class("max")),
 					Img(ID("feedback-loading"), Class("htmx-indicator"), Src("/shared/static/spinner.svg")),
@@ -234,6 +238,24 @@ func Index(title string, date string, mood string) Node {
 							Text("확인"),
 						),
 					),
+				),
+			),
+
+			/* 이미지 Dialog */
+			Dialog(ID("diary-image-dialog"), Class("max"),
+				H5(Text("이미지")),
+				Div(ID("diary-image-content"),
+					h.Get(fmt.Sprintf("/diary/images?date=%s", date)),
+					h.Trigger("load"),
+				),
+				Div(
+					Input(Type("file"), ID("diary-image-file")),
+					Nav(Class("right-align"),
+						Button(Type("button"), Attr("onclick", fmt.Sprintf("uploadDiaryImage('%s')", date)), Text("업로드")),
+					),
+				),
+				Nav(Class("right-align"),
+					Button(Attr("data-ui", "#diary-image-dialog"), Text("닫기")),
 				),
 			),
 


### PR DESCRIPTION
## Summary
- store uploaded image URLs in first empty diary slot
- trigger client-side Firebase upload and post URL to server
- update image dialog to use file input and upload button
- move Firebase Storage upload logic to dedicated module

## Testing
- `bash task.sh check`


------
https://chatgpt.com/codex/tasks/task_e_6891ca8d92e0832f8427358db7c02984