### PR TITLE
이미지 삭제 시 Firebase 저장소 정리

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ tool github.com/sqlc-dev/sqlc/cmd/sqlc
 tool github.com/golangci/golangci-lint/cmd/golangci-lint
 
 require (
+	cloud.google.com/go/storage v1.53.0
 	firebase.google.com/go/v4 v4.18.0
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Blank-Xu/sql-adapter v1.1.2
@@ -52,7 +53,6 @@ require (
 	cloud.google.com/go/iam v1.5.2 // indirect
 	cloud.google.com/go/longrunning v0.6.7 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
-	cloud.google.com/go/storage v1.53.0 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/4meepo/tagalign v1.4.2 // indirect

--- a/projects/deario/handlers/image_test.go
+++ b/projects/deario/handlers/image_test.go
@@ -1,0 +1,23 @@
+package handlers
+
+import "testing"
+
+func TestParseFirebaseURL(t *testing.T) {
+	raw := "https://firebasestorage.googleapis.com/v0/b/test-bucket/o/diary%2Fuid%2Fimg.png?alt=media&token=abc"
+	bucket, object, err := parseFirebaseURL(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bucket != "test-bucket" {
+		t.Fatalf("bucket mismatch: %s", bucket)
+	}
+	if object != "diary/uid/img.png" {
+		t.Fatalf("object mismatch: %s", object)
+	}
+}
+
+func TestParseFirebaseURL_Invalid(t *testing.T) {
+	if _, _, err := parseFirebaseURL("https://example.com"); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## 요약
- 일기 이미지 삭제 시 Firebase Storage에서도 파일 제거
- Firebase URL 파싱 및 삭제 유닛 테스트 추가

## 테스트
- `bash ./task.sh check`


------
https://chatgpt.com/codex/tasks/task_e_6892e0e1e73c832fa926b5cb806a7d35