### PR TITLE
feat: Deario 커스텀 달력 지원

### DIFF
--- a/cmd/deario/main.go
+++ b/cmd/deario/main.go
@@ -89,6 +89,7 @@ func setUpServer() *echo.Echo {
 		slog.Error("Casbin 권한 미들웨어 등록 실패", "error", err)
 		os.Exit(1)
 	}
+	authGroup.GET("/diary/month", handlers.MonthlyDiaryDates)
 	authGroup.GET("/diary/random", handlers.RedirectToRandomDiary)
 	authGroup.POST("/diary/save", handlers.SaveDiary)
 	authGroup.GET("/diary/search", handlers.SearchDiaries)

--- a/projects/deario/db/query.sql.go
+++ b/projects/deario/db/query.sql.go
@@ -169,6 +169,43 @@ func (q *Queries) GetUserSetting(ctx context.Context, uid string) (UserSetting, 
 	return i, err
 }
 
+const listDiaryDatesByMonth = `-- name: ListDiaryDatesByMonth :many
+SELECT date
+FROM diary
+WHERE
+    uid = ?
+    AND substr(date, 1, 6) = ?
+ORDER BY date
+`
+
+type ListDiaryDatesByMonthParams struct {
+	Uid  string
+	Date string
+}
+
+func (q *Queries) ListDiaryDatesByMonth(ctx context.Context, arg ListDiaryDatesByMonthParams) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listDiaryDatesByMonth, arg.Uid, arg.Date)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var date string
+		if err := rows.Scan(&date); err != nil {
+			return nil, err
+		}
+		items = append(items, date)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDiarys = `-- name: ListDiarys :many
 SELECT id, uid, date, content, ai_feedback, ai_image, created, updated, mood, image_url1, image_url2, image_url3
 FROM diary

--- a/projects/deario/handlers/diary.go
+++ b/projects/deario/handlers/diary.go
@@ -121,6 +121,34 @@ func ListDiaries(c echo.Context) error {
 	return Group(lis).Render(c.Response().Writer)
 }
 
+// MonthlyDiaryDates는 특정 월에 작성한 일기 날짜 목록을 반환한다.
+func MonthlyDiaryDates(c echo.Context) error {
+	uid, err := authutil.SessionUID(c)
+	if err != nil {
+		return err
+	}
+
+	month := c.QueryParam("month")
+	if month == "" {
+		month = time.Now().Format("200601")
+	}
+
+	queries, err := db.GetQueries(c.Request().Context())
+	if err != nil {
+		return err
+	}
+
+	dates, err := queries.ListDiaryDatesByMonth(c.Request().Context(), db.ListDiaryDatesByMonthParams{
+		Uid:  uid,
+		Date: month,
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "목록을 가져오지 못했습니다.")
+	}
+
+	return c.JSON(http.StatusOK, dates)
+}
+
 // RedirectToRandomDiary는 무작위 일기 날짜로 이동한다.
 func RedirectToRandomDiary(c echo.Context) error {
 	uid, err := authutil.SessionUID(c)

--- a/projects/deario/query.sql
+++ b/projects/deario/query.sql
@@ -22,6 +22,14 @@ ORDER BY created desc
 LIMIT 7
 OFFSET ((? - 1) * 7);
 
+-- name: ListDiaryDatesByMonth :many
+SELECT date
+FROM diary
+WHERE
+    uid = ?
+    AND substr(date, 1, 6) = ?
+ORDER BY date;
+
 -- name: SearchDiarys :many
 SELECT
     date,

--- a/projects/deario/static/calendar.js
+++ b/projects/deario/static/calendar.js
@@ -1,0 +1,45 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const el = document.getElementById("calendar-picker");
+  if (!el) return;
+  const fp = flatpickr(el, {
+    inline: true,
+    dateFormat: "Ymd",
+    onChange: function (_sel, dateStr) {
+      if (dateStr) {
+        location.href = "/?date=" + dateStr;
+      }
+    },
+    onMonthChange: function (_sel, _dateStr, instance) {
+      loadDiaryDates(instance);
+    },
+    onReady: function (_sel, _dateStr, instance) {
+      loadDiaryDates(instance);
+    },
+  });
+
+  async function loadDiaryDates(instance) {
+    const year = instance.currentYear;
+    const month = String(instance.currentMonth + 1).padStart(2, "0");
+    try {
+      const res = await fetch(`/diary/month?month=${year}${month}`);
+      if (!res.ok) return;
+      const dates = await res.json();
+      highlightDates(instance, dates);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  function highlightDates(instance, dates) {
+    instance.days
+      .querySelectorAll(".has-diary")
+      .forEach((e) => e.classList.remove("has-diary"));
+    dates.forEach((d) => {
+      const selector = `[aria-label="${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}"]`;
+      const dayElem = instance.days.querySelector(selector);
+      if (dayElem) {
+        dayElem.classList.add("has-diary");
+      }
+    });
+  }
+});

--- a/projects/deario/static/style.css
+++ b/projects/deario/static/style.css
@@ -104,3 +104,13 @@ svg {
   text-overflow: ellipsis;
   display: block;
 }
+
+.has-diary::after {
+  content: "";
+  display: block;
+  width: 4px;
+  height: 4px;
+  margin: 2px auto 0;
+  background: var(--primary);
+  border-radius: 50%;
+}

--- a/projects/deario/views/index.go
+++ b/projects/deario/views/index.go
@@ -26,8 +26,11 @@ func Index(title string, date string, mood string) Node {
 			shared.HeadGoogleFonts("Gamja Flower"),
 			[]Node{
 				Link(Rel("manifest"), Href("/manifest.json")),
+				Link(Rel("stylesheet"), Href("https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css")),
+				Script(Src("https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js")),
 				Script(Src("/static/deario.js")),
 				Script(Type("module"), Src("/static/storage.js")),
+				Script(Src("/static/calendar.js")),
 			},
 		),
 		Body: []Node{
@@ -149,9 +152,8 @@ func Index(title string, date string, mood string) Node {
 
 			/* Footer */
 			Nav(Class("bottom"),
-				A(
+				A(Attr("data-ui", "#calendar-dialog"),
 					I(Text("calendar_month")),
-					Input(Type("date"), Name("date"), Attr("onchange", "location.href='/?date=' + this.value")),
 					Text("달력"),
 				),
 				A(Attr("data-ui", "#diary-list-dialog"),
@@ -241,6 +243,14 @@ func Index(title string, date string, mood string) Node {
 							Text("확인"),
 						),
 					),
+				),
+			),
+
+			/* 달력 Dialog */
+			Dialog(ID("calendar-dialog"), Class("max"),
+				Div(ID("calendar-picker")),
+				Nav(Class("right-align"),
+					Button(Attr("data-ui", "#calendar-dialog"), Text("닫기")),
 				),
 			),
 


### PR DESCRIPTION
## Summary
- flatpickr 기반 달력 UI 추가 및 작성된 날짜 표시
- 월별 일기 날짜 조회 API 추가
- 하단 메뉴에서 달력 다이얼로그 호출하도록 수정

## Testing
- `bash ./task.sh check`

------
https://chatgpt.com/codex/tasks/task_e_689973f56f30832f92b2ebf69b3f2b78