### PR TITLE
flatpickr 다크 테마 자동 로딩

### DIFF
--- a/shared/static/app.js
+++ b/shared/static/app.js
@@ -67,6 +67,7 @@ document.addEventListener("alpine:init", () => {
       }
       window.ui("mode", this.value);
       window.ui("theme", this.color);
+      this.applyFlatpickrTheme(this.value);
     },
     set(theme) {
       this.value = theme;
@@ -76,6 +77,7 @@ document.addEventListener("alpine:init", () => {
       } catch (e) {
         console.error("localStorage save error", e);
       }
+      this.applyFlatpickrTheme(theme);
     },
     setColor(color) {
       this.color = color;
@@ -88,6 +90,22 @@ document.addEventListener("alpine:init", () => {
     },
     toggle() {
       this.set(this.value === "dark" ? "light" : "dark");
+    },
+    applyFlatpickrTheme(theme) {
+      const id = "flatpickr-dark";
+      const href = "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/themes/dark.css";
+      const link = document.getElementById(id);
+      if (theme === "dark") {
+        if (!link) {
+          const tag = document.createElement("link");
+          tag.id = id;
+          tag.rel = "stylesheet";
+          tag.href = href;
+          document.head.appendChild(tag);
+        }
+      } else if (link) {
+        link.remove();
+      }
     },
   });
 


### PR DESCRIPTION
## 요약
- 다크 모드 선택 시 flatpickr 다크 테마 CSS를 동적으로 로딩하고, 라이트 모드로 전환 시 제거하도록 구현

## 테스트
- `bash task.sh check`

------
https://chatgpt.com/codex/tasks/task_e_68999303a014832fbebd565c270f3b4f