### PR TITLE
deario: DB 연결 재사용으로 메모리 증가 문제 수정

### DIFF
--- a/projects/deario/db/util.go
+++ b/projects/deario/db/util.go
@@ -2,16 +2,48 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"sync"
+
 	"simple-server/internal/connection"
 )
 
-// GetQueries 는 DB 연결을 열고 쿼리 객체를 반환합니다
-func GetQueries(ctx context.Context) (*Queries, error) {
-	dbCon, err := connection.AppDBOpen()
-	if err != nil {
-		return nil, fmt.Errorf("데이터베이스 연결 실패: %w", err)
-	}
+var (
+	once    sync.Once
+	dbConn  *sql.DB
+	queries *Queries
+	errInit error
+)
 
-	return New(dbCon), nil
+func initDB() {
+	dbConn, errInit = connection.AppDBOpen()
+	if errInit == nil {
+		queries = New(dbConn)
+	}
+}
+
+// GetDB 는 공용 DB 연결을 반환합니다
+func GetDB() (*sql.DB, error) {
+	once.Do(initDB)
+	if errInit != nil {
+		return nil, fmt.Errorf("데이터베이스 연결 실패: %w", errInit)
+	}
+	return dbConn, nil
+}
+
+// GetQueries 는 공용 쿼리 객체를 반환합니다
+func GetQueries(ctx context.Context) (*Queries, error) {
+	if _, err := GetDB(); err != nil {
+		return nil, err
+	}
+	return queries, nil
+}
+
+// Close 는 공용 DB 연결을 종료합니다
+func Close() error {
+	if dbConn != nil {
+		return dbConn.Close()
+	}
+	return nil
 }

--- a/projects/deario/db/util_test.go
+++ b/projects/deario/db/util_test.go
@@ -1,0 +1,44 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetDBAndQueriesReuseConnection(t *testing.T) {
+	t.Setenv("APP_DATABASE_URL", "file::memory:?cache=shared")
+
+	ctx := context.Background()
+
+	q1, err := GetQueries(ctx)
+	if err != nil {
+		t.Fatalf("첫 번째 쿼리 객체 생성 실패: %v", err)
+	}
+
+	db1, err := GetDB()
+	if err != nil {
+		t.Fatalf("첫 번째 DB 연결 실패: %v", err)
+	}
+
+	q2, err := GetQueries(ctx)
+	if err != nil {
+		t.Fatalf("두 번째 쿼리 객체 생성 실패: %v", err)
+	}
+
+	db2, err := GetDB()
+	if err != nil {
+		t.Fatalf("두 번째 DB 연결 실패: %v", err)
+	}
+
+	if q1 != q2 {
+		t.Errorf("GetQueries가 다른 인스턴스를 반환했습니다")
+	}
+
+	if db1 != db2 {
+		t.Errorf("GetDB가 다른 인스턴스를 반환했습니다")
+	}
+
+	if err := Close(); err != nil {
+		t.Fatalf("DB 종료 실패: %v", err)
+	}
+}

--- a/projects/deario/tasks/aireport.go
+++ b/projects/deario/tasks/aireport.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	aiclient "simple-server/internal/ai"
-	"simple-server/internal/connection"
 	"simple-server/projects/deario/db"
 	"strings"
 	"time"
@@ -64,7 +63,7 @@ OO님, 지난 한 달 동안의 소중한 마음 기록들을 제가 조심스�
 }
 
 func GenerateAIReportJob() {
-	apiReportDb, err := connection.AppDBOpen(false)
+	apiReportDb, err := db.GetDB()
 	if err != nil {
 		slog.Error("데이터베이스 연결 실패", "error", err)
 		return

--- a/projects/deario/tasks/push.go
+++ b/projects/deario/tasks/push.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"time"
 
-	"simple-server/internal/connection"
 	"simple-server/internal/middleware"
 	"simple-server/projects/deario/db"
 
@@ -63,7 +62,7 @@ func PushSendCron(c *cron.Cron) {
 }
 
 func PushSendJob() {
-	pushdb, err := connection.AppDBOpen(false)
+	pushdb, err := db.GetDB()
 	if err != nil {
 		slog.Error("데이터베이스 연결 실패", "error", err)
 		return


### PR DESCRIPTION
## Summary
- DB 연결을 싱글톤으로 관리해 반복 생성에 따른 메모리 증가 방지
- 백그라운드 작업이 공용 DB를 사용하도록 수정
- DB 연결 재사용을 검증하는 단위 테스트 추가

## Testing
- `bash task.sh check`


------
https://chatgpt.com/codex/tasks/task_e_68999cb0d44c832fa1a4b14667fb55ae