### PR TITLE
db util initDB 오류 처리 개선

### DIFF
--- a/projects/deario/db/util.go
+++ b/projects/deario/db/util.go
@@ -18,12 +18,19 @@ var (
 )
 
 func initDB() {
-	dbConn, errInit = connection.AppDBOpen()
-	dbNotHookConn, errInit = connection.AppDBOpen(false)
-	if errInit == nil {
-		queries = New(dbConn)
-		queriesNotHook = New(dbNotHookConn)
+	var err error
+	dbConn, err = connection.AppDBOpen()
+	if err != nil {
+		errInit = err
+		return
 	}
+	dbNotHookConn, err = connection.AppDBOpen(false)
+	if err != nil {
+		errInit = err
+		return
+	}
+	queries = New(dbConn)
+	queriesNotHook = New(dbNotHookConn)
 }
 
 // GetDB 는 공용 DB 연결을 반환합니다


### PR DESCRIPTION
## Summary
- initDB에서 각 DB 연결의 에러를 분리 처리하고 첫 호출 실패 시 즉시 반환하도록 수정

## Testing
- `bash ./task.sh check`

------
https://chatgpt.com/codex/tasks/task_e_6899a84c5530832f8786988e4d9f6064