### PR TITLE
chore: close db in casbin init

### DIFF
--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -102,6 +102,7 @@ func InitCasbin() error {
 	if err != nil {
 		return fmt.Errorf("데이터베이스 연결 실패: %w", err)
 	}
+	defer db.Close()
 	adapter, err := sqladapter.NewAdapter(db, "sqlite", "")
 	if err != nil {
 		return fmt.Errorf("casbin adapter 초기화 실패: %w", err)


### PR DESCRIPTION
## Summary
- close temporary db connection in InitCasbin

## Testing
- `bash ./task.sh check`

------
https://chatgpt.com/codex/tasks/task_e_6899b7811ce8832fb3537cc080fc0d7f