### PR TITLE
fix: close DB connections in deario tasks

### DIFF
--- a/projects/deario/tasks/aireport.go
+++ b/projects/deario/tasks/aireport.go
@@ -68,6 +68,7 @@ func GenerateAIReportJob() {
 		slog.Error("데이터베이스 연결 실패", "error", err)
 		return
 	}
+	defer db.Close()
 	AiReportQ = goqite.New(goqite.NewOpts{
 		DB:   apiReportDb,
 		Name: "ai-report",
@@ -80,15 +81,15 @@ func GenerateAIReportJob() {
 		Queue:        AiReportQ,
 	})
 
+	queries, err := db.GetQueries(false)
+	if err != nil {
+		slog.Error("쿼리 객체 생성 실패", "error", err)
+		return
+	}
+
 	r.Register("ai-report", func(ctx context.Context, m []byte) error {
 		uid := string(m)
 		slog.Info("AI 리포트 생성 작업을 시작합니다.", "uid", uid)
-
-		queries, err := db.GetQueries()
-		if err != nil {
-			slog.Error("쿼리 객체 생성 실패", "uid", uid, "error", err)
-			return err
-		}
 
 		var allDiaries []db.Diary
 		// 한 페이지에 7개의 일기를 가져오므로, 5페이지를 조회하여 최대 35개의 최근 일기를 가져옴

--- a/projects/deario/tasks/push.go
+++ b/projects/deario/tasks/push.go
@@ -24,15 +24,15 @@ type Payload struct {
 var pushQ *goqite.Queue
 
 func PushSendCron(c *cron.Cron) {
+	queries, err := db.GetQueries(false)
+	if err != nil {
+		slog.Error("쿼리 로드 실패", "error", err)
+		return
+	}
+
 	if _, err := c.AddFunc("@every 1m", func() {
 		ctx := context.Background()
 		now := time.Now().Format("15:04")
-
-		queries, err := db.GetQueries()
-		if err != nil {
-			slog.Error("쿼리 로드 실패", "error", err)
-			return
-		}
 
 		targets, err := queries.ListPushTargets(ctx)
 		if err != nil {
@@ -67,6 +67,7 @@ func PushSendJob() {
 		slog.Error("데이터베이스 연결 실패", "error", err)
 		return
 	}
+	defer db.Close()
 	pushQ = goqite.New(goqite.NewOpts{
 		DB:   pushdb,
 		Name: "push",


### PR DESCRIPTION
## Summary
- close DB connections after push and AI report jobs
- reuse shared query instances for scheduled push job

## Testing
- `bash ./task.sh check`

------
https://chatgpt.com/codex/tasks/task_e_6899b754a450832f86ecb3a793cd1b03