### PR TITLE
feat: 단순 로그인 페이지와 인디케이터

### DIFF
--- a/shared/static/firebase_login.js
+++ b/shared/static/firebase_login.js
@@ -21,6 +21,9 @@ const uiConfig = {
   ],
   callbacks: {
     signInSuccessWithAuthResult: function (authResult, redirectUrl) {
+      loader.classList.remove("hidden");
+      loader.querySelector("span").textContent = "로그인 중...";
+
       authResult.user
         .getIdToken(true)
         .then((idToken) => {
@@ -58,11 +61,12 @@ const uiConfig = {
     uiShown: function () {
       // The widget is rendered.
       // Hide the loader.
-      document.getElementById("loader").style.display = "none";
+      loader.classList.add("hidden");
     },
   },
 };
 
 // (7) FirebaseUI 인스턴스 생성 및 초기화
+const loader = document.getElementById("loader");
 const ui = new firebaseui.auth.AuthUI(firebase.auth());
 ui.start("#firebaseui-auth-container", uiConfig);

--- a/shared/static/style.css
+++ b/shared/static/style.css
@@ -9,6 +9,32 @@
   outline-offset: 0 !important;
 }
 
+/* 로그인 페이지 */
+main.login-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+#firebaseui-auth-container {
+  width: 100%;
+  max-width: 360px;
+}
+
+#loader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+#loader.hidden {
+  display: none;
+}
+
 /*:root {*/
 /*    --pico-line-height: var(--font-lineheight-1);*/
 /*    !* Original: 1.5 /*/

--- a/shared/views/login.go
+++ b/shared/views/login.go
@@ -1,6 +1,8 @@
 package shared
 
 import (
+	"simple-server/pkg/util/gomutil"
+
 	. "maragu.dev/gomponents"
 	. "maragu.dev/gomponents/components"
 	. "maragu.dev/gomponents/html"
@@ -10,14 +12,18 @@ func Login() Node {
 	return HTML5(HTML5Props{
 		Title:    "로그인",
 		Language: "ko",
-		Head: append(
-			HeadsWithBeer("로그인"),
-			HeadWithFirebaseLogin()...,
+		Head: gomutil.MergeHeads(
+			HeadsDefault("로그인"),
+			HeadsCustom(),
+			HeadWithFirebaseLogin(),
 		),
 		Body: []Node{
-			Main(Class("responsive"),
+			Main(Class("login-page"),
 				Div(ID("firebaseui-auth-container")),
-				Div(ID("loader"), Text("Loading...")),
+				Div(ID("loader"),
+					Img(Src("/shared/static/spinner.svg"), Alt("로딩")),
+					Span(Text("로딩 중...")),
+				),
 			),
 		}},
 	)


### PR DESCRIPTION
## Summary
- 로그인 페이지에서 BeerCSS 제거하고 기본 헤더 구성으로 단순화
- 로딩 및 로그인 진행을 보여주는 인디케이터 추가
- 로그인 화면을 위한 CSS 스타일 추가

## Testing
- `bash task.sh check`


------
https://chatgpt.com/codex/tasks/task_e_689a91d99c40832f8826989313e23068