### PR TITLE
feat(deario): 사용자 폰트 설정과 즉시 적용

### DIFF
--- a/projects/deario/static/font.js
+++ b/projects/deario/static/font.js
@@ -1,0 +1,26 @@
+(function(){
+  window.applyUserFont = function(familySpec) {
+    if (!familySpec) return;
+    localStorage.setItem('uiFontFamily', familySpec);
+    var href = 'https://fonts.googleapis.com/css2?family=' + encodeURIComponent(familySpec) + '&display=swap';
+    var link = document.getElementById('user-font');
+    if (link) {
+      link.href = href;
+    } else {
+      link = document.createElement('link');
+      link.id = 'user-font';
+      link.rel = 'stylesheet';
+      link.href = href;
+      document.head.appendChild(link);
+    }
+    var familyName = familySpec.split(':')[0].replace(/\+/g, ' ');
+    document.documentElement.style.setProperty('--font-family', familyName + ', system-ui, sans-serif');
+  };
+
+  window.addEventListener('DOMContentLoaded', function() {
+    var select = document.getElementById('font-select');
+    if (!select) return;
+    var fam = localStorage.getItem('uiFontFamily') || 'Gamja+Flower';
+    select.value = fam;
+  });
+})();

--- a/projects/deario/views/index.go
+++ b/projects/deario/views/index.go
@@ -21,9 +21,9 @@ func Index(title string, date string, mood string) Node {
 		Title:    title,
 		Language: "ko",
 		Head: gomutil.MergeHeads(
+			shared.HeadUserFont(),
 			shared.HeadsWithBeer(title),
 			shared.HeadWithFirebaseAuth(),
-			shared.HeadGoogleFonts("Gamja Flower"),
 			shared.HeadFlatpickr(),
 			shared.HeadMarked(),
 			[]Node{

--- a/projects/deario/views/setting.go
+++ b/projects/deario/views/setting.go
@@ -21,9 +21,9 @@ func Setting(userSetting db.UserSetting) Node {
 		Title:    "설정",
 		Language: "ko",
 		Head: gomutil.MergeHeads(
+			shared.HeadUserFont(),
 			shared.HeadsWithBeer("설정"),
 			shared.HeadWithFirebaseAuth(),
-			shared.HeadGoogleFonts("Gamja Flower"),
 			[]Node{
 				Link(Rel("manifest"), Href("/manifest.json")),
 				Script(Src("/static/deario.js")),
@@ -82,6 +82,15 @@ func Setting(userSetting db.UserSetting) Node {
 									x.Model("$store.theme.color"),
 									x.On("change", "$store.theme.setColor($event.target.value)"),
 								),
+							),
+						),
+						// 폰트 변경
+						Nav(Text("폰트")),
+						Div(Class("field border label"),
+							Select(ID("font-select"), Attr("onchange", "applyUserFont(this.value)"),
+								Option(Value("Gamja+Flower"), Text("Gamja Flower")),
+								Option(Value("Inter:wght@400;700"), Text("Inter")),
+								Option(Value("Noto+Sans+KR:wght@400;700"), Text("Noto Sans KR")),
 							),
 						),
 						Nav(Class("right-align"),

--- a/projects/deario/views/statistic.go
+++ b/projects/deario/views/statistic.go
@@ -17,9 +17,9 @@ func Statistic() Node {
 		Title:    "통계",
 		Language: "ko",
 		Head: gomutil.MergeHeads(
+			shared.HeadUserFont(),
 			shared.HeadsWithBeer("통계"),
 			shared.HeadWithFirebaseAuth(),
-			shared.HeadGoogleFonts("Gamja Flower"),
 			[]Node{
 				Link(Rel("manifest"), Href("/manifest.json")),
 				Script(Src("https://cdn.jsdelivr.net/npm/chart.js")),

--- a/shared/views/head.go
+++ b/shared/views/head.go
@@ -115,6 +115,26 @@ func HeadGoogleFonts(font ...string) []Node {
 	}
 }
 
+func HeadUserFont() []Node {
+	script := `(function () {
+                var fam = localStorage.getItem('uiFontFamily') || 'Gamja+Flower'
+                var href = 'https://fonts.googleapis.com/css2?family=' + encodeURIComponent(fam) + '&display=swap'
+                var link = document.createElement('link')
+                link.id = 'user-font'
+                link.rel = 'stylesheet'
+                link.href = href
+                document.head.appendChild(link)
+                var familyName = fam.split(':')[0].replace(/\+/g, ' ')
+                document.documentElement.style.setProperty('--font-family', familyName + ', system-ui, sans-serif')
+        })();`
+
+	return []Node{
+		Link(Rel("preconnect"), Href("https://fonts.gstatic.com"), Attr("crossorigin", "")),
+		Script(Text(script)),
+		Script(Src("/static/font.js")),
+	}
+}
+
 func HeadFlatpickr() []Node {
 	return []Node{
 		Link(Rel("stylesheet"), Href("https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css"),


### PR DESCRIPTION
## Summary
- 설정 페이지에 폰트 선택 기능을 추가하고 로컬스토리지에 저장
- 저장된 폰트를 초기 로딩 시 즉시 적용하는 스크립트 도입
- 공통 Head 헬퍼에 사용자 폰트 로드 기능 추가

## Testing
- `bash task.sh check`


------
https://chatgpt.com/codex/tasks/task_e_689bfa895ee0832fb7ba80908218ed3f