### PR TITLE
feat(deario): 일기 작성에 WYSIWYG 에디터 적용

### DIFF
--- a/projects/deario/static/deario.js
+++ b/projects/deario/static/deario.js
@@ -14,6 +14,24 @@ document.addEventListener("alpine:init", () => {
   });
 });
 
+document.addEventListener("DOMContentLoaded", () => {
+  const textarea = document.querySelector("textarea[name='content']");
+  if (!textarea) return;
+  const editor = pell.init({
+    element: document.getElementById("editor"),
+    onChange: (html) => {
+      textarea.value = html;
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+  });
+  editor.content.innerHTML = textarea.value;
+  editor.content.setAttribute(
+    "data-placeholder",
+    textarea.getAttribute("placeholder"),
+  );
+  editor.content.focus();
+});
+
 function showAiFeedback() {
   const mdEl = document.getElementById("ai-feedback-markdown");
   if (mdEl && mdEl.textContent) {

--- a/projects/deario/static/style.css
+++ b/projects/deario/static/style.css
@@ -114,3 +114,8 @@ body {
   background: var(--primary);
   border-radius: 50%;
 }
+
+.pell-content:empty::before {
+  content: attr(data-placeholder);
+  color: #888;
+}

--- a/projects/deario/views/index.go
+++ b/projects/deario/views/index.go
@@ -29,6 +29,8 @@ func Index(title string, date string, mood string) Node {
 			[]Node{
 				Meta(Name("description"), Content("AI 피드백 일기 서비스")),
 				Link(Rel("manifest"), Href("/manifest.json")),
+				Link(Rel("stylesheet"), Href("https://unpkg.com/pell/dist/pell.min.css")),
+				Script(Src("https://unpkg.com/pell")),
 				Script(Src("/static/deario.js")),
 				Script(Src("/static/calendar.js")),
 				Script(Type("module"), Src("/static/storage.js")),
@@ -348,9 +350,9 @@ func DiaryContentForm(date string, content string) Node {
 	return Form(ID("diary"),
 		Input(Type("hidden"), Name("date"), Value(date)),
 		Div(Class("field textarea border u-fit-h‑18rem"),
+			Div(ID("editor")),
 			Textarea(
 				Name("content"),
-				AutoFocus(),
 				x.Data(""),
 				h.Post("/diary/save"),
 				h.Swap("none"),
@@ -359,6 +361,7 @@ func DiaryContentForm(date string, content string) Node {
 				Attr("@htmx:after-request", "$store.save.ok()"),
 				Attr("aria-label", "일기 내용"),
 				Attr("placeholder", "오늘의 일기를 입력하세요"),
+				Style("display: none"),
 				Text(content),
 			),
 		),


### PR DESCRIPTION
## 요약
- pell 라이브러리 도입으로 일기 작성에 WYSIWYG 에디터 적용
- pell 초기화 스크립트 및 placeholder 스타일 추가

## 테스트
- `bash task.sh check`


------
https://chatgpt.com/codex/tasks/task_e_68a57e17a378832fa78d841de3daa55d