### PR TITLE
feat(deario): 음성 녹음 일기 작성 지원

### DIFF
--- a/cmd/deario/main.go
+++ b/cmd/deario/main.go
@@ -120,6 +120,7 @@ func setUpServer() *echo.Echo {
 	authGroup.GET("/diary/images", handlers.DiaryImagesPage)
 	authGroup.POST("/diary/image", handlers.UploadDiaryImage)
 	authGroup.DELETE("/diary/image", handlers.DeleteDiaryImage)
+	authGroup.POST("/diary/transcribe", handlers.TranscribeDiaryVoice)
 	/* 권한 라우터 */
 
 	/* 큐 리시버 */

--- a/internal/ai/speech.go
+++ b/internal/ai/speech.go
@@ -1,0 +1,39 @@
+package aiclient
+
+import (
+	"context"
+	"fmt"
+	"simple-server/internal/config"
+
+	"google.golang.org/genai"
+)
+
+// TranscribeAudio는 음성 데이터를 텍스트로 변환한다.
+func TranscribeAudio(ctx context.Context, data []byte, mimeType string) (string, error) {
+	if len(data) == 0 {
+		return "", fmt.Errorf("오디오 데이터가 비어있습니다")
+	}
+	if config.EnvMap["GEMINI_AI_KEY"] == "" {
+		return "", fmt.Errorf("AI 키가 설정되지 않았습니다")
+	}
+	client, err := genai.NewClient(ctx, &genai.ClientConfig{
+		APIKey:  config.EnvMap["GEMINI_AI_KEY"],
+		Backend: genai.BackendGeminiAPI,
+	})
+	if err != nil {
+		return "", fmt.Errorf("AI 클라이언트 생성 실패: %w", err)
+	}
+	parts := []*genai.Part{
+		{Text: "다음 오디오 내용을 한국어 텍스트로 변환해줘."},
+		{InlineData: &genai.Blob{Data: data, MIMEType: mimeType}},
+	}
+	contents := []*genai.Content{{Parts: parts}}
+	result, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
+	if err != nil {
+		return "", fmt.Errorf("오디오 인식 요청 실패: %w", err)
+	}
+	if len(result.Candidates) == 0 || len(result.Candidates[0].Content.Parts) == 0 {
+		return "", fmt.Errorf("응답이 비어있습니다")
+	}
+	return result.Candidates[0].Content.Parts[0].Text, nil
+}

--- a/internal/ai/speech_test.go
+++ b/internal/ai/speech_test.go
@@ -1,0 +1,23 @@
+package aiclient
+
+import (
+	"context"
+	"testing"
+
+	"simple-server/internal/config"
+)
+
+func TestTranscribeAudio(t *testing.T) {
+	config.EnvMap = map[string]string{}
+	t.Run("empty data", func(t *testing.T) {
+		if _, err := TranscribeAudio(context.Background(), nil, "audio/webm"); err == nil {
+			t.Fatalf("error expected")
+		}
+	})
+
+	t.Run("missing api key", func(t *testing.T) {
+		if _, err := TranscribeAudio(context.Background(), []byte{1}, "audio/webm"); err == nil {
+			t.Fatalf("error expected")
+		}
+	})
+}

--- a/projects/deario/handlers/voice.go
+++ b/projects/deario/handlers/voice.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+
+	aiclient "simple-server/internal/ai"
+	"simple-server/pkg/util/authutil"
+
+	"github.com/labstack/echo/v4"
+)
+
+// TranscribeDiaryVoice는 업로드된 음성을 텍스트로 변환한다.
+func TranscribeDiaryVoice(c echo.Context) error {
+	uid, err := authutil.SessionUID(c)
+	if err != nil {
+		return err
+	}
+	file, err := c.FormFile("audio")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "오디오 파일이 필요합니다.")
+	}
+	src, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	data, err := io.ReadAll(src)
+	if err != nil {
+		return err
+	}
+	slog.Debug("음성 일기 변환", "user", uid, "size", len(data))
+	text, err := aiclient.TranscribeAudio(c.Request().Context(), data, file.Header.Get("Content-Type"))
+	if err != nil {
+		slog.Error("음성 인식 실패", "error", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "음성 인식에 실패했습니다.")
+	}
+	return c.String(http.StatusOK, text)
+}

--- a/projects/deario/static/voice.js
+++ b/projects/deario/static/voice.js
@@ -1,0 +1,45 @@
+let recorder;
+let chunks = [];
+
+async function toggleRecord(btn) {
+  if (recorder && recorder.state === "recording") {
+    recorder.stop();
+    btn.classList.remove("primary");
+    btn.innerText = "mic";
+    return;
+  }
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    recorder = new MediaRecorder(stream);
+    chunks = [];
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunks.push(e.data);
+    };
+    recorder.onstop = async () => {
+      const blob = new Blob(chunks, { type: "audio/webm" });
+      const fd = new FormData();
+      fd.append("audio", blob, "recording.webm");
+      try {
+        const res = await fetch("/diary/transcribe", { method: "POST", body: fd });
+        if (res.ok) {
+          const text = await res.text();
+          const textarea = document.querySelector("#diary textarea[name='content']");
+          if (textarea) {
+            textarea.value += (textarea.value ? "\n" : "") + text;
+            textarea.dispatchEvent(new Event("input"));
+          }
+        } else {
+          showInfo("음성 인식 실패");
+        }
+      } catch {
+        showInfo("음성 인식 실패");
+      }
+    };
+    recorder.start();
+    btn.classList.add("primary");
+    btn.innerText = "stop";
+  } catch {
+    showInfo("마이크 접근 실패");
+  }
+}
+

--- a/projects/deario/views/index.go
+++ b/projects/deario/views/index.go
@@ -32,6 +32,7 @@ func Index(title string, date string, mood string) Node {
 				Link(Rel("manifest"), Href("/manifest.json")),
 				Script(Src("/static/deario.js")),
 				Script(Src("/static/calendar.js")),
+				Script(Src("/static/voice.js")),
 				Script(Type("module"), Src("/static/storage.js")),
 			},
 		),
@@ -363,6 +364,11 @@ func DiaryContentForm(date string, content string) Node {
 				Attr("aria-label", "일기 내용"),
 				Attr("placeholder", "오늘의 일기를 입력하세요"),
 				Text(content),
+			),
+		),
+		Nav(
+			Button(Type("button"), Class("chip circle"), Attr("onclick", "toggleRecord(this)"),
+				I(Text("mic")),
 			),
 		),
 	)


### PR DESCRIPTION
## Summary
- 일기 음성을 텍스트로 변환하는 AI 클라이언트 추가
- 음성 업로드 후 텍스트 반환하는 핸들러 및 라우트 구현
- 녹음 버튼과 스크립트로 프론트에서 바로 일기에 입력 가능

## Testing
- `go test ./internal/ai -run TestTranscribeAudio -count=1`
- `bash ./task.sh check`

------
https://chatgpt.com/codex/tasks/task_e_68b84600b748832f888b461b22747aa5