### PR TITLE
Add portfolio data entry services and forms

### DIFF
--- a/cmd/portfolio/main.go
+++ b/cmd/portfolio/main.go
@@ -96,6 +96,13 @@ func setUpServer() *echo.Echo {
 		slog.Error("Casbin 권한 미들웨어 등록 실패", "error", err)
 		os.Exit(1)
 	}
+	authGroup.POST("/categories", handlers.CreateCategory)
+	authGroup.POST("/securities", handlers.CreateSecurity)
+	authGroup.POST("/accounts", handlers.CreateAccount)
+	authGroup.POST("/holdings", handlers.CreateHolding)
+	authGroup.POST("/allocation-targets", handlers.CreateAllocationTarget)
+	authGroup.POST("/budget-entries", handlers.CreateBudgetEntry)
+	authGroup.POST("/contribution-plans", handlers.CreateContributionPlan)
 	/* 권한 라우터 */
 
 	return e

--- a/projects/portfolio/db/models.go
+++ b/projects/portfolio/db/models.go
@@ -8,6 +8,68 @@ import (
 	"database/sql"
 )
 
+type Account struct {
+	ID             string
+	Uid            string
+	CategoryID     string
+	Name           string
+	Provider       string
+	Balance        int64
+	MonthlyContrib int64
+	Note           string
+	Created        sql.NullString
+	Updated        sql.NullString
+}
+
+type AllocationTarget struct {
+	ID           string
+	Uid          string
+	CategoryID   string
+	TargetWeight float64
+	TargetAmount int64
+	Note         string
+}
+
+type BudgetEntry struct {
+	ID        string
+	Uid       string
+	Name      string
+	Direction string
+	Class     string
+	Planned   int64
+	Actual    int64
+	Note      string
+	Created   sql.NullString
+	Updated   sql.NullString
+}
+
+type Category struct {
+	ID           string
+	Uid          string
+	Name         string
+	Role         string
+	ParentID     sql.NullString
+	DisplayOrder int64
+}
+
+type ContributionPlan struct {
+	ID         string
+	Uid        string
+	SecurityID string
+	Weight     float64
+	Amount     int64
+	Note       string
+}
+
+type Holding struct {
+	ID           string
+	Uid          string
+	SecurityID   string
+	Amount       int64
+	TargetAmount int64
+	Note         string
+}
+
 type PushKey struct {
 	ID      string
 	Uid     string
@@ -16,10 +78,45 @@ type PushKey struct {
 	Updated sql.NullString
 }
 
+type Security struct {
+	ID         string
+	Uid        string
+	Symbol     string
+	Name       string
+	Type       string
+	CategoryID sql.NullString
+	Currency   string
+	Note       string
+}
+
 type User struct {
 	Uid     string
 	Name    string
 	Email   string
 	Created sql.NullString
 	Updated sql.NullString
+}
+
+type VCategoryAllocation struct {
+	Uid          string
+	CategoryID   string
+	CategoryName string
+	Amount       interface{}
+	WeightPct    float64
+}
+
+type VRebalanceGap struct {
+	Uid            string
+	CategoryID     string
+	TargetWeight   float64
+	TargetAmount   int64
+	CurrentAmount  interface{}
+	TargetByWeight float64
+	TargetFinal    interface{}
+	GapAmount      int64
+}
+
+type VTotalAsset struct {
+	Uid         string
+	TotalAmount int64
 }

--- a/projects/portfolio/db/query.sql.go
+++ b/projects/portfolio/db/query.sql.go
@@ -7,7 +7,188 @@ package db
 
 import (
 	"context"
+	"database/sql"
 )
+
+const createAccount = `-- name: CreateAccount :exec
+INSERT INTO account (uid, category_id, name, provider, balance, monthly_contrib, note)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`
+
+type CreateAccountParams struct {
+	Uid            string
+	CategoryID     string
+	Name           string
+	Provider       string
+	Balance        int64
+	MonthlyContrib int64
+	Note           string
+}
+
+func (q *Queries) CreateAccount(ctx context.Context, arg CreateAccountParams) error {
+	_, err := q.db.ExecContext(ctx, createAccount,
+		arg.Uid,
+		arg.CategoryID,
+		arg.Name,
+		arg.Provider,
+		arg.Balance,
+		arg.MonthlyContrib,
+		arg.Note,
+	)
+	return err
+}
+
+const createAllocationTarget = `-- name: CreateAllocationTarget :exec
+INSERT INTO allocation_target (uid, category_id, target_weight, target_amount, note)
+VALUES (?, ?, ?, ?, ?)
+`
+
+type CreateAllocationTargetParams struct {
+	Uid          string
+	CategoryID   string
+	TargetWeight float64
+	TargetAmount int64
+	Note         string
+}
+
+func (q *Queries) CreateAllocationTarget(ctx context.Context, arg CreateAllocationTargetParams) error {
+	_, err := q.db.ExecContext(ctx, createAllocationTarget,
+		arg.Uid,
+		arg.CategoryID,
+		arg.TargetWeight,
+		arg.TargetAmount,
+		arg.Note,
+	)
+	return err
+}
+
+const createBudgetEntry = `-- name: CreateBudgetEntry :exec
+INSERT INTO budget_entry (uid, name, direction, class, planned, actual, note)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`
+
+type CreateBudgetEntryParams struct {
+	Uid       string
+	Name      string
+	Direction string
+	Class     string
+	Planned   int64
+	Actual    int64
+	Note      string
+}
+
+func (q *Queries) CreateBudgetEntry(ctx context.Context, arg CreateBudgetEntryParams) error {
+	_, err := q.db.ExecContext(ctx, createBudgetEntry,
+		arg.Uid,
+		arg.Name,
+		arg.Direction,
+		arg.Class,
+		arg.Planned,
+		arg.Actual,
+		arg.Note,
+	)
+	return err
+}
+
+const createCategory = `-- name: CreateCategory :exec
+INSERT INTO category (uid, name, role, parent_id, display_order)
+VALUES (?, ?, ?, ?, ?)
+`
+
+type CreateCategoryParams struct {
+	Uid          string
+	Name         string
+	Role         string
+	ParentID     sql.NullString
+	DisplayOrder int64
+}
+
+func (q *Queries) CreateCategory(ctx context.Context, arg CreateCategoryParams) error {
+	_, err := q.db.ExecContext(ctx, createCategory,
+		arg.Uid,
+		arg.Name,
+		arg.Role,
+		arg.ParentID,
+		arg.DisplayOrder,
+	)
+	return err
+}
+
+const createContributionPlan = `-- name: CreateContributionPlan :exec
+INSERT INTO contribution_plan (uid, security_id, weight, amount, note)
+VALUES (?, ?, ?, ?, ?)
+`
+
+type CreateContributionPlanParams struct {
+	Uid        string
+	SecurityID string
+	Weight     float64
+	Amount     int64
+	Note       string
+}
+
+func (q *Queries) CreateContributionPlan(ctx context.Context, arg CreateContributionPlanParams) error {
+	_, err := q.db.ExecContext(ctx, createContributionPlan,
+		arg.Uid,
+		arg.SecurityID,
+		arg.Weight,
+		arg.Amount,
+		arg.Note,
+	)
+	return err
+}
+
+const createHolding = `-- name: CreateHolding :exec
+INSERT INTO holding (uid, security_id, amount, target_amount, note)
+VALUES (?, ?, ?, ?, ?)
+`
+
+type CreateHoldingParams struct {
+	Uid          string
+	SecurityID   string
+	Amount       int64
+	TargetAmount int64
+	Note         string
+}
+
+func (q *Queries) CreateHolding(ctx context.Context, arg CreateHoldingParams) error {
+	_, err := q.db.ExecContext(ctx, createHolding,
+		arg.Uid,
+		arg.SecurityID,
+		arg.Amount,
+		arg.TargetAmount,
+		arg.Note,
+	)
+	return err
+}
+
+const createSecurity = `-- name: CreateSecurity :exec
+INSERT INTO security (uid, symbol, name, type, category_id, currency, note)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`
+
+type CreateSecurityParams struct {
+	Uid        string
+	Symbol     string
+	Name       string
+	Type       string
+	CategoryID sql.NullString
+	Currency   string
+	Note       string
+}
+
+func (q *Queries) CreateSecurity(ctx context.Context, arg CreateSecurityParams) error {
+	_, err := q.db.ExecContext(ctx, createSecurity,
+		arg.Uid,
+		arg.Symbol,
+		arg.Name,
+		arg.Type,
+		arg.CategoryID,
+		arg.Currency,
+		arg.Note,
+	)
+	return err
+}
 
 const createUser = `-- name: CreateUser :exec
 INSERT INTO user (uid, name, email) VALUES (?, ?, ?)
@@ -22,6 +203,19 @@ type CreateUserParams struct {
 func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) error {
 	_, err := q.db.ExecContext(ctx, createUser, arg.Uid, arg.Name, arg.Email)
 	return err
+}
+
+const getTotalAsset = `-- name: GetTotalAsset :one
+SELECT uid, total_amount
+FROM v_total_asset
+WHERE uid = ?
+`
+
+func (q *Queries) GetTotalAsset(ctx context.Context, uid string) (VTotalAsset, error) {
+	row := q.db.QueryRowContext(ctx, getTotalAsset, uid)
+	var i VTotalAsset
+	err := row.Scan(&i.Uid, &i.TotalAmount)
+	return i, err
 }
 
 const getUser = `-- name: GetUser :one
@@ -41,4 +235,510 @@ func (q *Queries) GetUser(ctx context.Context, uid string) (User, error) {
 		&i.Updated,
 	)
 	return i, err
+}
+
+const listAccounts = `-- name: ListAccounts :many
+SELECT
+    a.id,
+    a.uid,
+    a.category_id,
+    a.name,
+    a.provider,
+    a.balance,
+    a.monthly_contrib,
+    a.note,
+    c.name AS category_name
+FROM account a
+JOIN category c ON c.id = a.category_id
+WHERE a.uid = ?
+ORDER BY c.display_order, a.name
+`
+
+type ListAccountsRow struct {
+	ID             string
+	Uid            string
+	CategoryID     string
+	Name           string
+	Provider       string
+	Balance        int64
+	MonthlyContrib int64
+	Note           string
+	CategoryName   string
+}
+
+func (q *Queries) ListAccounts(ctx context.Context, uid string) ([]ListAccountsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAccounts, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAccountsRow
+	for rows.Next() {
+		var i ListAccountsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.CategoryID,
+			&i.Name,
+			&i.Provider,
+			&i.Balance,
+			&i.MonthlyContrib,
+			&i.Note,
+			&i.CategoryName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAllocationTargets = `-- name: ListAllocationTargets :many
+SELECT
+    a.id,
+    a.uid,
+    a.category_id,
+    a.target_weight,
+    a.target_amount,
+    a.note,
+    c.name AS category_name
+FROM allocation_target a
+JOIN category c ON c.id = a.category_id
+WHERE a.uid = ?
+ORDER BY c.display_order
+`
+
+type ListAllocationTargetsRow struct {
+	ID           string
+	Uid          string
+	CategoryID   string
+	TargetWeight float64
+	TargetAmount int64
+	Note         string
+	CategoryName string
+}
+
+func (q *Queries) ListAllocationTargets(ctx context.Context, uid string) ([]ListAllocationTargetsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAllocationTargets, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAllocationTargetsRow
+	for rows.Next() {
+		var i ListAllocationTargetsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.CategoryID,
+			&i.TargetWeight,
+			&i.TargetAmount,
+			&i.Note,
+			&i.CategoryName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listBudgetEntries = `-- name: ListBudgetEntries :many
+SELECT
+    id,
+    uid,
+    name,
+    direction,
+    class,
+    planned,
+    actual,
+    note
+FROM budget_entry
+WHERE uid = ?
+ORDER BY
+    CASE direction WHEN 'income' THEN 0 ELSE 1 END,
+    CASE class WHEN 'fixed' THEN 0 ELSE 1 END,
+    name
+`
+
+type ListBudgetEntriesRow struct {
+	ID        string
+	Uid       string
+	Name      string
+	Direction string
+	Class     string
+	Planned   int64
+	Actual    int64
+	Note      string
+}
+
+func (q *Queries) ListBudgetEntries(ctx context.Context, uid string) ([]ListBudgetEntriesRow, error) {
+	rows, err := q.db.QueryContext(ctx, listBudgetEntries, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListBudgetEntriesRow
+	for rows.Next() {
+		var i ListBudgetEntriesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.Name,
+			&i.Direction,
+			&i.Class,
+			&i.Planned,
+			&i.Actual,
+			&i.Note,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCategories = `-- name: ListCategories :many
+SELECT
+    id,
+    uid,
+    name,
+    role,
+    parent_id,
+    display_order
+FROM category
+WHERE uid = ?
+ORDER BY display_order, name
+`
+
+func (q *Queries) ListCategories(ctx context.Context, uid string) ([]Category, error) {
+	rows, err := q.db.QueryContext(ctx, listCategories, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Category
+	for rows.Next() {
+		var i Category
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.Name,
+			&i.Role,
+			&i.ParentID,
+			&i.DisplayOrder,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCategoryAllocations = `-- name: ListCategoryAllocations :many
+SELECT v.uid, v.category_id, v.category_name, v.amount, v.weight_pct
+FROM v_category_allocation v
+JOIN category c ON c.id = v.category_id AND c.uid = v.uid
+WHERE v.uid = ?
+ORDER BY c.display_order
+`
+
+func (q *Queries) ListCategoryAllocations(ctx context.Context, uid string) ([]VCategoryAllocation, error) {
+	rows, err := q.db.QueryContext(ctx, listCategoryAllocations, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []VCategoryAllocation
+	for rows.Next() {
+		var i VCategoryAllocation
+		if err := rows.Scan(
+			&i.Uid,
+			&i.CategoryID,
+			&i.CategoryName,
+			&i.Amount,
+			&i.WeightPct,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listContributionPlans = `-- name: ListContributionPlans :many
+SELECT
+    cp.id,
+    cp.uid,
+    cp.security_id,
+    cp.weight,
+    cp.amount,
+    cp.note,
+    s.symbol AS security_symbol,
+    s.name AS security_name,
+    s.category_id AS security_category_id,
+    c.name AS category_name
+FROM contribution_plan cp
+JOIN security s ON s.id = cp.security_id
+LEFT JOIN category c ON c.id = s.category_id
+WHERE cp.uid = ?
+ORDER BY cp.weight DESC, s.name
+`
+
+type ListContributionPlansRow struct {
+	ID                 string
+	Uid                string
+	SecurityID         string
+	Weight             float64
+	Amount             int64
+	Note               string
+	SecuritySymbol     string
+	SecurityName       string
+	SecurityCategoryID sql.NullString
+	CategoryName       sql.NullString
+}
+
+func (q *Queries) ListContributionPlans(ctx context.Context, uid string) ([]ListContributionPlansRow, error) {
+	rows, err := q.db.QueryContext(ctx, listContributionPlans, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListContributionPlansRow
+	for rows.Next() {
+		var i ListContributionPlansRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.SecurityID,
+			&i.Weight,
+			&i.Amount,
+			&i.Note,
+			&i.SecuritySymbol,
+			&i.SecurityName,
+			&i.SecurityCategoryID,
+			&i.CategoryName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listHoldings = `-- name: ListHoldings :many
+SELECT
+    h.id,
+    h.uid,
+    h.security_id,
+    h.amount,
+    h.target_amount,
+    h.note,
+    s.symbol AS security_symbol,
+    s.name AS security_name,
+    s.type AS security_type,
+    s.category_id AS security_category_id,
+    c.name AS category_name,
+    s.currency AS security_currency
+FROM holding h
+JOIN security s ON s.id = h.security_id
+LEFT JOIN category c ON c.id = s.category_id
+WHERE h.uid = ?
+ORDER BY c.display_order, s.name
+`
+
+type ListHoldingsRow struct {
+	ID                 string
+	Uid                string
+	SecurityID         string
+	Amount             int64
+	TargetAmount       int64
+	Note               string
+	SecuritySymbol     string
+	SecurityName       string
+	SecurityType       string
+	SecurityCategoryID sql.NullString
+	CategoryName       sql.NullString
+	SecurityCurrency   string
+}
+
+func (q *Queries) ListHoldings(ctx context.Context, uid string) ([]ListHoldingsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listHoldings, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListHoldingsRow
+	for rows.Next() {
+		var i ListHoldingsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.SecurityID,
+			&i.Amount,
+			&i.TargetAmount,
+			&i.Note,
+			&i.SecuritySymbol,
+			&i.SecurityName,
+			&i.SecurityType,
+			&i.SecurityCategoryID,
+			&i.CategoryName,
+			&i.SecurityCurrency,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRebalanceGaps = `-- name: ListRebalanceGaps :many
+SELECT
+    g.uid,
+    g.category_id,
+    c.name AS category_name,
+    g.target_weight,
+    g.target_amount,
+    g.current_amount,
+    g.target_by_weight,
+    g.target_final,
+    g.gap_amount
+FROM v_rebalance_gap g
+JOIN category c ON c.id = g.category_id
+WHERE g.uid = ?
+ORDER BY c.display_order
+`
+
+type ListRebalanceGapsRow struct {
+	Uid            string
+	CategoryID     string
+	CategoryName   string
+	TargetWeight   float64
+	TargetAmount   int64
+	CurrentAmount  interface{}
+	TargetByWeight float64
+	TargetFinal    interface{}
+	GapAmount      int64
+}
+
+func (q *Queries) ListRebalanceGaps(ctx context.Context, uid string) ([]ListRebalanceGapsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listRebalanceGaps, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRebalanceGapsRow
+	for rows.Next() {
+		var i ListRebalanceGapsRow
+		if err := rows.Scan(
+			&i.Uid,
+			&i.CategoryID,
+			&i.CategoryName,
+			&i.TargetWeight,
+			&i.TargetAmount,
+			&i.CurrentAmount,
+			&i.TargetByWeight,
+			&i.TargetFinal,
+			&i.GapAmount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSecurities = `-- name: ListSecurities :many
+SELECT
+    id,
+    uid,
+    symbol,
+    name,
+    type,
+    category_id,
+    currency,
+    note
+FROM security
+WHERE uid = ?
+ORDER BY name
+`
+
+func (q *Queries) ListSecurities(ctx context.Context, uid string) ([]Security, error) {
+	rows, err := q.db.QueryContext(ctx, listSecurities, uid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Security
+	for rows.Next() {
+		var i Security
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.Symbol,
+			&i.Name,
+			&i.Type,
+			&i.CategoryID,
+			&i.Currency,
+			&i.Note,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/projects/portfolio/handlers/manage.go
+++ b/projects/portfolio/handlers/manage.go
@@ -1,0 +1,184 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"simple-server/pkg/util/authutil"
+	"simple-server/projects/portfolio/services"
+	"simple-server/projects/portfolio/views"
+
+	"github.com/labstack/echo/v4"
+)
+
+func CreateCategory(c echo.Context) error {
+	uid, err := requireUID(c)
+	if err != nil {
+		return err
+	}
+
+	input := services.CreateCategoryInput{
+		Name:         c.FormValue("name"),
+		Role:         c.FormValue("role"),
+		ParentID:     c.FormValue("parent_id"),
+		DisplayOrder: c.FormValue("display_order"),
+	}
+
+	if err := services.CreateCategory(c.Request().Context(), uid, input); err != nil {
+		return handleServiceError(err, "카테고리를 저장하지 못했습니다.")
+	}
+
+	return renderDashboard(c, uid)
+}
+
+func CreateSecurity(c echo.Context) error {
+	uid, err := requireUID(c)
+	if err != nil {
+		return err
+	}
+
+	input := services.CreateSecurityInput{
+		Symbol:     c.FormValue("symbol"),
+		Name:       c.FormValue("name"),
+		Type:       c.FormValue("type"),
+		CategoryID: c.FormValue("category_id"),
+		Currency:   c.FormValue("currency"),
+		Note:       c.FormValue("note"),
+	}
+
+	if err := services.CreateSecurity(c.Request().Context(), uid, input); err != nil {
+		return handleServiceError(err, "종목을 저장하지 못했습니다.")
+	}
+
+	return renderDashboard(c, uid)
+}
+
+func CreateAccount(c echo.Context) error {
+	uid, err := requireUID(c)
+	if err != nil {
+		return err
+	}
+
+	input := services.CreateAccountInput{
+		CategoryID:     c.FormValue("category_id"),
+		Name:           c.FormValue("name"),
+		Provider:       c.FormValue("provider"),
+		Balance:        c.FormValue("balance"),
+		MonthlyContrib: c.FormValue("monthly_contrib"),
+		Note:           c.FormValue("note"),
+	}
+
+	if err := services.CreateAccount(c.Request().Context(), uid, input); err != nil {
+		return handleServiceError(err, "계좌를 저장하지 못했습니다.")
+	}
+
+	return renderDashboard(c, uid)
+}
+
+func CreateHolding(c echo.Context) error {
+	uid, err := requireUID(c)
+	if err != nil {
+		return err
+	}
+
+	input := services.CreateHoldingInput{
+		SecurityID:   c.FormValue("security_id"),
+		Amount:       c.FormValue("amount"),
+		TargetAmount: c.FormValue("target_amount"),
+		Note:         c.FormValue("note"),
+	}
+
+	if err := services.CreateHolding(c.Request().Context(), uid, input); err != nil {
+		return handleServiceError(err, "보유 종목을 저장하지 못했습니다.")
+	}
+
+	return renderDashboard(c, uid)
+}
+
+func CreateAllocationTarget(c echo.Context) error {
+	uid, err := requireUID(c)
+	if err != nil {
+		return err
+	}
+
+	input := services.CreateAllocationTargetInput{
+		CategoryID:   c.FormValue("category_id"),
+		TargetWeight: c.FormValue("target_weight"),
+		TargetAmount: c.FormValue("target_amount"),
+		Note:         c.FormValue("note"),
+	}
+
+	if err := services.CreateAllocationTarget(c.Request().Context(), uid, input); err != nil {
+		return handleServiceError(err, "리밸런싱 목표를 저장하지 못했습니다.")
+	}
+
+	return renderDashboard(c, uid)
+}
+
+func CreateBudgetEntry(c echo.Context) error {
+	uid, err := requireUID(c)
+	if err != nil {
+		return err
+	}
+
+	input := services.CreateBudgetEntryInput{
+		Name:      c.FormValue("name"),
+		Direction: c.FormValue("direction"),
+		Class:     c.FormValue("class"),
+		Planned:   c.FormValue("planned"),
+		Actual:    c.FormValue("actual"),
+		Note:      c.FormValue("note"),
+	}
+
+	if err := services.CreateBudgetEntry(c.Request().Context(), uid, input); err != nil {
+		return handleServiceError(err, "예산 항목을 저장하지 못했습니다.")
+	}
+
+	return renderDashboard(c, uid)
+}
+
+func CreateContributionPlan(c echo.Context) error {
+	uid, err := requireUID(c)
+	if err != nil {
+		return err
+	}
+
+	input := services.CreateContributionPlanInput{
+		SecurityID: c.FormValue("security_id"),
+		Weight:     c.FormValue("weight"),
+		Amount:     c.FormValue("amount"),
+		Note:       c.FormValue("note"),
+	}
+
+	if err := services.CreateContributionPlan(c.Request().Context(), uid, input); err != nil {
+		return handleServiceError(err, "적립 계획을 저장하지 못했습니다.")
+	}
+
+	return renderDashboard(c, uid)
+}
+
+func requireUID(c echo.Context) (string, error) {
+	uid, err := authutil.SessionUID(c)
+	if err != nil {
+		return "", echo.NewHTTPError(http.StatusUnauthorized, "로그인이 필요합니다.")
+	}
+	return uid, nil
+}
+
+func renderDashboard(c echo.Context, uid string) error {
+	snapshot, err := services.LoadPortfolio(c.Request().Context(), uid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "포트폴리오 데이터를 새로고침하지 못했습니다.")
+	}
+
+	c.Response().Header().Set(echo.HeaderContentType, "text/html; charset=utf-8")
+	return views.DashboardContent(snapshot).Render(c.Response().Writer)
+}
+
+func handleServiceError(err error, fallback string) error {
+	var vErr *services.ValidationError
+	if errors.As(err, &vErr) {
+		return echo.NewHTTPError(http.StatusBadRequest, vErr.Message)
+	}
+	return echo.NewHTTPError(http.StatusInternalServerError, fallback)
+}

--- a/projects/portfolio/handlers/portfolio.go
+++ b/projects/portfolio/handlers/portfolio.go
@@ -1,13 +1,32 @@
 package handlers
 
 import (
+	"net/http"
 	"os"
 
+	"simple-server/pkg/util/authutil"
+	"simple-server/projects/portfolio/services"
 	"simple-server/projects/portfolio/views"
 
 	"github.com/labstack/echo/v4"
 )
 
 func IndexPage(c echo.Context) error {
-	return views.Index(os.Getenv("APP_TITLE")).Render(c.Response().Writer)
+	title := os.Getenv("APP_TITLE")
+
+	uid, err := authutil.SessionUID(c)
+	if err != nil {
+		uid = services.DemoUID
+	}
+
+	snapshot, err := services.LoadPortfolio(c.Request().Context(), uid)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "포트폴리오 데이터를 불러오지 못했습니다.")
+	}
+
+	if uid == services.DemoUID {
+		snapshot.IsDemo = true
+	}
+
+	return views.Index(title, snapshot).Render(c.Response().Writer)
 }

--- a/projects/portfolio/migrations/002_portfolio_core.sql
+++ b/projects/portfolio/migrations/002_portfolio_core.sql
@@ -1,0 +1,236 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS category (
+    id TEXT PRIMARY KEY DEFAULT ('cat_' || LOWER(HEX(RANDOMBLOB(7)))),
+    uid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('liquidity', 'growth', 'income', 'protection', 'other')),
+    parent_id TEXT DEFAULT NULL,
+    display_order INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(uid, name),
+    FOREIGN KEY(parent_id) REFERENCES category(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS security (
+    id TEXT PRIMARY KEY DEFAULT ('sec_' || LOWER(HEX(RANDOMBLOB(7)))),
+    uid TEXT NOT NULL,
+    symbol TEXT NOT NULL DEFAULT '',
+    name TEXT NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('stock', 'etf', 'fund', 'bond', 'crypto', 'other')),
+    category_id TEXT DEFAULT NULL,
+    currency TEXT NOT NULL DEFAULT 'KRW',
+    note TEXT NOT NULL DEFAULT '',
+    UNIQUE(uid, name),
+    FOREIGN KEY(category_id) REFERENCES category(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS account (
+    id TEXT PRIMARY KEY DEFAULT ('acc_' || LOWER(HEX(RANDOMBLOB(7)))),
+    uid TEXT NOT NULL,
+    category_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL DEFAULT '',
+    balance INTEGER NOT NULL DEFAULT 0,
+    monthly_contrib INTEGER NOT NULL DEFAULT 0,
+    note TEXT NOT NULL DEFAULT '',
+    created TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(category_id) REFERENCES category(id) ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS holding (
+    id TEXT PRIMARY KEY DEFAULT ('h_' || LOWER(HEX(RANDOMBLOB(7)))),
+    uid TEXT NOT NULL,
+    security_id TEXT NOT NULL,
+    amount INTEGER NOT NULL DEFAULT 0,
+    target_amount INTEGER NOT NULL DEFAULT 0,
+    note TEXT NOT NULL DEFAULT '',
+    UNIQUE(uid, security_id),
+    FOREIGN KEY(security_id) REFERENCES security(id) ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS allocation_target (
+    id TEXT PRIMARY KEY DEFAULT ('at_' || LOWER(HEX(RANDOMBLOB(7)))),
+    uid TEXT NOT NULL,
+    category_id TEXT NOT NULL,
+    target_weight REAL NOT NULL DEFAULT 0 CHECK (target_weight >= 0 AND target_weight <= 100),
+    target_amount INTEGER NOT NULL DEFAULT 0,
+    note TEXT NOT NULL DEFAULT '',
+    UNIQUE(uid, category_id),
+    FOREIGN KEY(category_id) REFERENCES category(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS budget_entry (
+    id TEXT PRIMARY KEY DEFAULT ('be_' || LOWER(HEX(RANDOMBLOB(7)))),
+    uid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    direction TEXT NOT NULL CHECK (direction IN ('income', 'expense')),
+    class TEXT NOT NULL CHECK (class IN ('fixed', 'variable')),
+    planned INTEGER NOT NULL DEFAULT 0,
+    actual INTEGER NOT NULL DEFAULT 0,
+    note TEXT NOT NULL DEFAULT '',
+    created TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS contribution_plan (
+    id TEXT PRIMARY KEY DEFAULT ('cp_' || LOWER(HEX(RANDOMBLOB(7)))),
+    uid TEXT NOT NULL,
+    security_id TEXT NOT NULL,
+    weight REAL NOT NULL DEFAULT 0 CHECK (weight >= 0 AND weight <= 100),
+    amount INTEGER NOT NULL DEFAULT 0,
+    note TEXT NOT NULL DEFAULT '',
+    UNIQUE(uid, security_id),
+    FOREIGN KEY(security_id) REFERENCES security(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_category_uid ON category(uid, display_order);
+CREATE INDEX IF NOT EXISTS idx_account_uid ON account(uid);
+CREATE INDEX IF NOT EXISTS idx_holding_uid ON holding(uid);
+CREATE INDEX IF NOT EXISTS idx_budget_uid ON budget_entry(uid);
+CREATE INDEX IF NOT EXISTS idx_plan_uid ON contribution_plan(uid);
+
+CREATE VIEW IF NOT EXISTS v_total_asset AS
+SELECT
+    u.uid,
+    COALESCE((SELECT SUM(balance) FROM account a WHERE a.uid = u.uid), 0) +
+    COALESCE((SELECT SUM(h.amount) FROM holding h WHERE h.uid = u.uid), 0) AS total_amount
+FROM (SELECT DISTINCT uid FROM account UNION SELECT DISTINCT uid FROM holding) u;
+
+CREATE VIEW IF NOT EXISTS v_category_allocation AS
+SELECT
+    c.uid,
+    c.id AS category_id,
+    c.name AS category_name,
+    (COALESCE(acc.sum_balance, 0) + COALESCE(h.sum_holding, 0)) AS amount,
+    ROUND(
+        100.0 * (COALESCE(acc.sum_balance, 0) + COALESCE(h.sum_holding, 0)) /
+        NULLIF(t.total_amount, 0),
+        2
+    ) AS weight_pct
+FROM category c
+LEFT JOIN (
+    SELECT category_id, uid, SUM(balance) AS sum_balance
+    FROM account
+    GROUP BY uid, category_id
+) acc ON acc.category_id = c.id AND acc.uid = c.uid
+LEFT JOIN (
+    SELECT s.category_id, h.uid, SUM(h.amount) AS sum_holding
+    FROM holding h
+    JOIN security s ON s.id = h.security_id
+    GROUP BY h.uid, s.category_id
+) h ON h.category_id = c.id AND h.uid = c.uid
+LEFT JOIN v_total_asset t ON t.uid = c.uid;
+
+CREATE VIEW IF NOT EXISTS v_rebalance_gap AS
+SELECT
+    a.uid,
+    a.category_id,
+    a.target_weight,
+    a.target_amount,
+    v.amount AS current_amount,
+    ROUND((a.target_weight / 100.0) * t.total_amount) AS target_by_weight,
+    COALESCE(
+        NULLIF(a.target_amount, 0),
+        ROUND((a.target_weight / 100.0) * t.total_amount)
+    ) AS target_final,
+    COALESCE(
+        NULLIF(a.target_amount, 0),
+        ROUND((a.target_weight / 100.0) * t.total_amount)
+    ) - v.amount AS gap_amount
+FROM allocation_target a
+JOIN v_category_allocation v ON v.category_id = a.category_id AND v.uid = a.uid
+JOIN v_total_asset t ON t.uid = a.uid;
+
+-- 샘플 데이터
+INSERT OR IGNORE INTO user (uid, name, email)
+VALUES ('uid_demo_portfolio', '김포트', 'portfolio-demo@example.com');
+
+INSERT INTO category (id, uid, name, role, display_order)
+VALUES
+    ('cat_cash', 'uid_demo_portfolio', '현금', 'liquidity', 1),
+    ('cat_savings', 'uid_demo_portfolio', '예금', 'liquidity', 2),
+    ('cat_domestic_stock', 'uid_demo_portfolio', '국내 주식', 'growth', 3),
+    ('cat_overseas_stock', 'uid_demo_portfolio', '해외 주식', 'growth', 4),
+    ('cat_domestic_bond', 'uid_demo_portfolio', '국내 채권', 'income', 5),
+    ('cat_overseas_bond', 'uid_demo_portfolio', '해외 채권', 'income', 6),
+    ('cat_retirement', 'uid_demo_portfolio', '연금', 'protection', 7),
+    ('cat_alternative', 'uid_demo_portfolio', '대체 투자', 'other', 8);
+
+INSERT INTO security (id, uid, symbol, name, type, category_id, currency, note)
+VALUES
+    ('sec_cash_fund', 'uid_demo_portfolio', 'CASH001', '머니마켓 펀드', 'fund', 'cat_cash', 'KRW', '단기 유동성 자산'),
+    ('sec_kospi200', 'uid_demo_portfolio', '069500', 'KODEX 200', 'etf', 'cat_domestic_stock', 'KRW', '국내 대표 지수 추종'),
+    ('sec_sp500', 'uid_demo_portfolio', '295820', 'TIGER 미국S&P500', 'etf', 'cat_overseas_stock', 'KRW', '원화 환헤지 없음'),
+    ('sec_usbond', 'uid_demo_portfolio', '448310', 'TIGER 미국채10년선물', 'etf', 'cat_overseas_bond', 'KRW', '장기채권 분산'),
+    ('sec_nasdaq', 'uid_demo_portfolio', '133690', 'TIGER 나스닥100', 'etf', 'cat_overseas_stock', 'KRW', '성장주 비중 확대'),
+    ('sec_dividend', 'uid_demo_portfolio', '314250', 'SMART 배당주', 'etf', 'cat_domestic_stock', 'KRW', '국내 고배당 ETF'),
+    ('sec_reit', 'uid_demo_portfolio', 'A372000', 'ESR 켄달스퀘어 리츠', 'stock', 'cat_alternative', 'KRW', '리츠 편입'),
+    ('sec_retirement_bond', 'uid_demo_portfolio', 'RET001', '퇴직연금 채권형', 'fund', 'cat_retirement', 'KRW', '퇴직연금 기본형 상품');
+
+INSERT INTO account (id, uid, category_id, name, provider, balance, monthly_contrib, note)
+VALUES
+    ('acc_checking', 'uid_demo_portfolio', 'cat_cash', '입출금 통장', '카카오뱅크', 2500000, 1500000, '생활비 계좌'),
+    ('acc_savings', 'uid_demo_portfolio', 'cat_savings', '파킹 예금', '토스뱅크', 32000000, 500000, '비상금 및 단기 목표'),
+    ('acc_retire', 'uid_demo_portfolio', 'cat_retirement', '퇴직연금(우리)', '우리은행', 48700000, 500000, '퇴직연금 DC형'),
+    ('acc_domestic_bond', 'uid_demo_portfolio', 'cat_domestic_bond', '국내 채권 CMA', 'NH투자', 7800000, 200000, '단기채 중심'),
+    ('acc_overseas_bond', 'uid_demo_portfolio', 'cat_overseas_bond', '달러 표시 채권형', '신한은행', 6200000, 200000, '환 노출 상품'),
+    ('acc_alternative', 'uid_demo_portfolio', 'cat_alternative', '부동산 펀드', 'KB증권', 9500000, 0, '만기 2년 남음');
+
+INSERT INTO holding (id, uid, security_id, amount, target_amount, note)
+VALUES
+    ('h_kospi200', 'uid_demo_portfolio', 'sec_kospi200', 28500000, 30000000, ''),
+    ('h_sp500', 'uid_demo_portfolio', 'sec_sp500', 31200000, 32000000, ''),
+    ('h_usbond', 'uid_demo_portfolio', 'sec_usbond', 8400000, 9000000, '리밸런싱 예정'),
+    ('h_nasdaq', 'uid_demo_portfolio', 'sec_nasdaq', 22800000, 24000000, ''),
+    ('h_dividend', 'uid_demo_portfolio', 'sec_dividend', 15600000, 15000000, '분기 배당 재투자'),
+    ('h_reit', 'uid_demo_portfolio', 'sec_reit', 7800000, 8000000, '배당 수익 재투자'),
+    ('h_retirement', 'uid_demo_portfolio', 'sec_retirement_bond', 50300000, 52000000, '퇴직연금 비중 유지');
+
+INSERT INTO allocation_target (id, uid, category_id, target_weight, target_amount, note)
+VALUES
+    ('at_cash', 'uid_demo_portfolio', 'cat_cash', 5, 5000000, '생활비 2개월 분'),
+    ('at_savings', 'uid_demo_portfolio', 'cat_savings', 20, 30000000, ''),
+    ('at_domestic_stock', 'uid_demo_portfolio', 'cat_domestic_stock', 25, 38000000, ''),
+    ('at_overseas_stock', 'uid_demo_portfolio', 'cat_overseas_stock', 25, 38000000, '미국 주식 중심'),
+    ('at_overseas_bond', 'uid_demo_portfolio', 'cat_overseas_bond', 10, 15000000, ''),
+    ('at_retirement', 'uid_demo_portfolio', 'cat_retirement', 10, 20000000, ''),
+    ('at_alternative', 'uid_demo_portfolio', 'cat_alternative', 5, 8000000, '리츠 및 대체투자');
+
+INSERT INTO budget_entry (id, uid, name, direction, class, planned, actual, note)
+VALUES
+    ('be_salary', 'uid_demo_portfolio', '급여', 'income', 'fixed', 5500000, 5500000, ''),
+    ('be_bonus', 'uid_demo_portfolio', '성과급', 'income', 'variable', 500000, 600000, '분기 실적에 따라 변동'),
+    ('be_side', 'uid_demo_portfolio', '부업 수입', 'income', 'variable', 300000, 250000, ''),
+    ('be_rent', 'uid_demo_portfolio', '월세', 'expense', 'fixed', 1200000, 1200000, ''),
+    ('be_living', 'uid_demo_portfolio', '생활비', 'expense', 'variable', 900000, 950000, '식비/교통/통신 포함'),
+    ('be_invest', 'uid_demo_portfolio', '투자 적립', 'expense', 'fixed', 1500000, 1500000, ''),
+    ('be_travel', 'uid_demo_portfolio', '여가/여행', 'expense', 'variable', 300000, 280000, ''),
+    ('be_education', 'uid_demo_portfolio', '자기계발', 'expense', 'variable', 200000, 150000, '온라인 강의 구독');
+
+INSERT INTO contribution_plan (id, uid, security_id, weight, amount, note)
+VALUES
+    ('cp_kospi200', 'uid_demo_portfolio', 'sec_kospi200', 25, 350000, ''),
+    ('cp_sp500', 'uid_demo_portfolio', 'sec_sp500', 25, 350000, '환율 상황에 따라 조정'),
+    ('cp_nasdaq', 'uid_demo_portfolio', 'sec_nasdaq', 20, 280000, ''),
+    ('cp_dividend', 'uid_demo_portfolio', 'sec_dividend', 15, 210000, ''),
+    ('cp_usbond', 'uid_demo_portfolio', 'sec_usbond', 10, 140000, ''),
+    ('cp_reit', 'uid_demo_portfolio', 'sec_reit', 5, 70000, '');
+
+-- +goose Down
+DROP VIEW IF EXISTS v_rebalance_gap;
+DROP VIEW IF EXISTS v_category_allocation;
+DROP VIEW IF EXISTS v_total_asset;
+
+DROP INDEX IF EXISTS idx_plan_uid;
+DROP INDEX IF EXISTS idx_budget_uid;
+DROP INDEX IF EXISTS idx_holding_uid;
+DROP INDEX IF EXISTS idx_account_uid;
+DROP INDEX IF EXISTS idx_category_uid;
+
+DROP TABLE IF EXISTS contribution_plan;
+DROP TABLE IF EXISTS budget_entry;
+DROP TABLE IF EXISTS allocation_target;
+DROP TABLE IF EXISTS holding;
+DROP TABLE IF EXISTS account;
+DROP TABLE IF EXISTS security;
+DROP TABLE IF EXISTS category;

--- a/projects/portfolio/query.sql
+++ b/projects/portfolio/query.sql
@@ -5,3 +5,170 @@ SELECT * FROM user WHERE uid = ? LIMIT 1;
 
 -- name: CreateUser :exec
 INSERT INTO user (uid, name, email) VALUES (?, ?, ?);
+
+-- name: GetTotalAsset :one
+SELECT uid, total_amount
+FROM v_total_asset
+WHERE uid = ?;
+
+-- name: ListCategoryAllocations :many
+SELECT v.uid, v.category_id, v.category_name, v.amount, v.weight_pct
+FROM v_category_allocation v
+JOIN category c ON c.id = v.category_id AND c.uid = v.uid
+WHERE v.uid = ?
+ORDER BY c.display_order;
+
+-- name: ListAccounts :many
+SELECT
+    a.id,
+    a.uid,
+    a.category_id,
+    a.name,
+    a.provider,
+    a.balance,
+    a.monthly_contrib,
+    a.note,
+    c.name AS category_name
+FROM account a
+JOIN category c ON c.id = a.category_id
+WHERE a.uid = ?
+ORDER BY c.display_order, a.name;
+
+-- name: ListHoldings :many
+SELECT
+    h.id,
+    h.uid,
+    h.security_id,
+    h.amount,
+    h.target_amount,
+    h.note,
+    s.symbol AS security_symbol,
+    s.name AS security_name,
+    s.type AS security_type,
+    s.category_id AS security_category_id,
+    c.name AS category_name,
+    s.currency AS security_currency
+FROM holding h
+JOIN security s ON s.id = h.security_id
+LEFT JOIN category c ON c.id = s.category_id
+WHERE h.uid = ?
+ORDER BY c.display_order, s.name;
+
+-- name: ListAllocationTargets :many
+SELECT
+    a.id,
+    a.uid,
+    a.category_id,
+    a.target_weight,
+    a.target_amount,
+    a.note,
+    c.name AS category_name
+FROM allocation_target a
+JOIN category c ON c.id = a.category_id
+WHERE a.uid = ?
+ORDER BY c.display_order;
+
+-- name: ListRebalanceGaps :many
+SELECT
+    g.uid,
+    g.category_id,
+    c.name AS category_name,
+    g.target_weight,
+    g.target_amount,
+    g.current_amount,
+    g.target_by_weight,
+    g.target_final,
+    g.gap_amount
+FROM v_rebalance_gap g
+JOIN category c ON c.id = g.category_id
+WHERE g.uid = ?
+ORDER BY c.display_order;
+
+-- name: ListBudgetEntries :many
+SELECT
+    id,
+    uid,
+    name,
+    direction,
+    class,
+    planned,
+    actual,
+    note
+FROM budget_entry
+WHERE uid = ?
+ORDER BY
+    CASE direction WHEN 'income' THEN 0 ELSE 1 END,
+    CASE class WHEN 'fixed' THEN 0 ELSE 1 END,
+    name;
+
+-- name: ListContributionPlans :many
+SELECT
+    cp.id,
+    cp.uid,
+    cp.security_id,
+    cp.weight,
+    cp.amount,
+    cp.note,
+    s.symbol AS security_symbol,
+    s.name AS security_name,
+    s.category_id AS security_category_id,
+    c.name AS category_name
+FROM contribution_plan cp
+JOIN security s ON s.id = cp.security_id
+LEFT JOIN category c ON c.id = s.category_id
+WHERE cp.uid = ?
+ORDER BY cp.weight DESC, s.name;
+
+-- name: ListCategories :many
+SELECT
+    id,
+    uid,
+    name,
+    role,
+    parent_id,
+    display_order
+FROM category
+WHERE uid = ?
+ORDER BY display_order, name;
+
+-- name: ListSecurities :many
+SELECT
+    id,
+    uid,
+    symbol,
+    name,
+    type,
+    category_id,
+    currency,
+    note
+FROM security
+WHERE uid = ?
+ORDER BY name;
+
+-- name: CreateCategory :exec
+INSERT INTO category (uid, name, role, parent_id, display_order)
+VALUES (?, ?, ?, ?, ?);
+
+-- name: CreateSecurity :exec
+INSERT INTO security (uid, symbol, name, type, category_id, currency, note)
+VALUES (?, ?, ?, ?, ?, ?, ?);
+
+-- name: CreateAccount :exec
+INSERT INTO account (uid, category_id, name, provider, balance, monthly_contrib, note)
+VALUES (?, ?, ?, ?, ?, ?, ?);
+
+-- name: CreateHolding :exec
+INSERT INTO holding (uid, security_id, amount, target_amount, note)
+VALUES (?, ?, ?, ?, ?);
+
+-- name: CreateAllocationTarget :exec
+INSERT INTO allocation_target (uid, category_id, target_weight, target_amount, note)
+VALUES (?, ?, ?, ?, ?);
+
+-- name: CreateBudgetEntry :exec
+INSERT INTO budget_entry (uid, name, direction, class, planned, actual, note)
+VALUES (?, ?, ?, ?, ?, ?, ?);
+
+-- name: CreateContributionPlan :exec
+INSERT INTO contribution_plan (uid, security_id, weight, amount, note)
+VALUES (?, ?, ?, ?, ?);

--- a/projects/portfolio/services/manage.go
+++ b/projects/portfolio/services/manage.go
@@ -1,0 +1,408 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"simple-server/projects/portfolio/db"
+)
+
+type ValidationError struct {
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
+type CreateCategoryInput struct {
+	Name         string
+	Role         string
+	ParentID     string
+	DisplayOrder string
+}
+
+type CreateSecurityInput struct {
+	Symbol     string
+	Name       string
+	Type       string
+	CategoryID string
+	Currency   string
+	Note       string
+}
+
+type CreateAccountInput struct {
+	CategoryID     string
+	Name           string
+	Provider       string
+	Balance        string
+	MonthlyContrib string
+	Note           string
+}
+
+type CreateHoldingInput struct {
+	SecurityID   string
+	Amount       string
+	TargetAmount string
+	Note         string
+}
+
+type CreateAllocationTargetInput struct {
+	CategoryID   string
+	TargetWeight string
+	TargetAmount string
+	Note         string
+}
+
+type CreateBudgetEntryInput struct {
+	Name      string
+	Direction string
+	Class     string
+	Planned   string
+	Actual    string
+	Note      string
+}
+
+type CreateContributionPlanInput struct {
+	SecurityID string
+	Weight     string
+	Amount     string
+	Note       string
+}
+
+func CreateCategory(ctx context.Context, uid string, input CreateCategoryInput) error {
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return &ValidationError{Message: "카테고리명을 입력해 주세요."}
+	}
+
+	role := strings.TrimSpace(input.Role)
+	if !isValidCategoryRole(role) {
+		return &ValidationError{Message: "카테고리 유형을 선택해 주세요."}
+	}
+
+	displayOrder, err := parseIntField(input.DisplayOrder, "정렬 순서는 숫자로 입력해 주세요.")
+	if err != nil {
+		return err
+	}
+
+	parentID := strings.TrimSpace(input.ParentID)
+	var parent sql.NullString
+	if parentID != "" {
+		parent = sql.NullString{String: parentID, Valid: true}
+	}
+
+	return withQueries(func(queries *db.Queries) error {
+		if err := queries.CreateCategory(ctx, db.CreateCategoryParams{
+			Uid:          uid,
+			Name:         name,
+			Role:         role,
+			ParentID:     parent,
+			DisplayOrder: displayOrder,
+		}); err != nil {
+			return fmt.Errorf("카테고리 저장 실패: %w", err)
+		}
+		return nil
+	})
+}
+
+func CreateSecurity(ctx context.Context, uid string, input CreateSecurityInput) error {
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return &ValidationError{Message: "종목명을 입력해 주세요."}
+	}
+
+	stype := strings.TrimSpace(input.Type)
+	if !isValidSecurityType(stype) {
+		return &ValidationError{Message: "종목 유형을 선택해 주세요."}
+	}
+
+	symbol := strings.TrimSpace(input.Symbol)
+	currency := strings.TrimSpace(input.Currency)
+	if currency == "" {
+		currency = "KRW"
+	}
+
+	categoryID := strings.TrimSpace(input.CategoryID)
+	var category sql.NullString
+	if categoryID != "" {
+		category = sql.NullString{String: categoryID, Valid: true}
+	}
+
+	note := strings.TrimSpace(input.Note)
+
+	return withQueries(func(queries *db.Queries) error {
+		if err := queries.CreateSecurity(ctx, db.CreateSecurityParams{
+			Uid:        uid,
+			Symbol:     symbol,
+			Name:       name,
+			Type:       stype,
+			CategoryID: category,
+			Currency:   currency,
+			Note:       note,
+		}); err != nil {
+			return fmt.Errorf("종목 저장 실패: %w", err)
+		}
+		return nil
+	})
+}
+
+func CreateAccount(ctx context.Context, uid string, input CreateAccountInput) error {
+	categoryID := strings.TrimSpace(input.CategoryID)
+	if categoryID == "" {
+		return &ValidationError{Message: "계좌 카테고리를 선택해 주세요."}
+	}
+
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return &ValidationError{Message: "계좌명을 입력해 주세요."}
+	}
+
+	balance, err := parseIntField(input.Balance, "잔액은 숫자로 입력해 주세요.")
+	if err != nil {
+		return err
+	}
+
+	monthly, err := parseIntField(input.MonthlyContrib, "월 납입액은 숫자로 입력해 주세요.")
+	if err != nil {
+		return err
+	}
+
+	provider := strings.TrimSpace(input.Provider)
+	note := strings.TrimSpace(input.Note)
+
+	return withQueries(func(queries *db.Queries) error {
+		if err := queries.CreateAccount(ctx, db.CreateAccountParams{
+			Uid:            uid,
+			CategoryID:     categoryID,
+			Name:           name,
+			Provider:       provider,
+			Balance:        balance,
+			MonthlyContrib: monthly,
+			Note:           note,
+		}); err != nil {
+			return fmt.Errorf("계좌 저장 실패: %w", err)
+		}
+		return nil
+	})
+}
+
+func CreateHolding(ctx context.Context, uid string, input CreateHoldingInput) error {
+	securityID := strings.TrimSpace(input.SecurityID)
+	if securityID == "" {
+		return &ValidationError{Message: "보유 종목을 선택해 주세요."}
+	}
+
+	amount, err := parseIntField(input.Amount, "현재 금액은 숫자로 입력해 주세요.")
+	if err != nil {
+		return err
+	}
+
+	target, err := parseIntField(input.TargetAmount, "목표 금액은 숫자로 입력해 주세요.")
+	if err != nil {
+		return err
+	}
+
+	note := strings.TrimSpace(input.Note)
+
+	return withQueries(func(queries *db.Queries) error {
+		if err := queries.CreateHolding(ctx, db.CreateHoldingParams{
+			Uid:          uid,
+			SecurityID:   securityID,
+			Amount:       amount,
+			TargetAmount: target,
+			Note:         note,
+		}); err != nil {
+			return fmt.Errorf("보유 종목 저장 실패: %w", err)
+		}
+		return nil
+	})
+}
+
+func CreateAllocationTarget(ctx context.Context, uid string, input CreateAllocationTargetInput) error {
+	categoryID := strings.TrimSpace(input.CategoryID)
+	if categoryID == "" {
+		return &ValidationError{Message: "목표 카테고리를 선택해 주세요."}
+	}
+
+	weight, amount, err := parseWeightAndAmount(
+		input.TargetWeight,
+		"목표 비중은 숫자로 입력해 주세요.",
+		"목표 비중은 0~100 사이로 입력해 주세요.",
+		input.TargetAmount,
+		"목표 금액은 숫자로 입력해 주세요.",
+	)
+	if err != nil {
+		return err
+	}
+
+	note := strings.TrimSpace(input.Note)
+
+	return withQueries(func(queries *db.Queries) error {
+		if err := queries.CreateAllocationTarget(ctx, db.CreateAllocationTargetParams{
+			Uid:          uid,
+			CategoryID:   categoryID,
+			TargetWeight: weight,
+			TargetAmount: amount,
+			Note:         note,
+		}); err != nil {
+			return fmt.Errorf("리밸런싱 목표 저장 실패: %w", err)
+		}
+		return nil
+	})
+}
+
+func CreateBudgetEntry(ctx context.Context, uid string, input CreateBudgetEntryInput) error {
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		return &ValidationError{Message: "예산 항목명을 입력해 주세요."}
+	}
+
+	direction := strings.TrimSpace(input.Direction)
+	if direction != "income" && direction != "expense" {
+		return &ValidationError{Message: "수입/지출 구분을 선택해 주세요."}
+	}
+
+	class := strings.TrimSpace(input.Class)
+	if class != "fixed" && class != "variable" {
+		return &ValidationError{Message: "고정/유동 구분을 선택해 주세요."}
+	}
+
+	planned, err := parseIntField(input.Planned, "계획 금액은 숫자로 입력해 주세요.")
+	if err != nil {
+		return err
+	}
+
+	actual, err := parseIntField(input.Actual, "실제 금액은 숫자로 입력해 주세요.")
+	if err != nil {
+		return err
+	}
+
+	note := strings.TrimSpace(input.Note)
+
+	return withQueries(func(queries *db.Queries) error {
+		if err := queries.CreateBudgetEntry(ctx, db.CreateBudgetEntryParams{
+			Uid:       uid,
+			Name:      name,
+			Direction: direction,
+			Class:     class,
+			Planned:   planned,
+			Actual:    actual,
+			Note:      note,
+		}); err != nil {
+			return fmt.Errorf("예산 항목 저장 실패: %w", err)
+		}
+		return nil
+	})
+}
+
+func CreateContributionPlan(ctx context.Context, uid string, input CreateContributionPlanInput) error {
+	securityID := strings.TrimSpace(input.SecurityID)
+	if securityID == "" {
+		return &ValidationError{Message: "적립할 종목을 선택해 주세요."}
+	}
+
+	weight, amount, err := parseWeightAndAmount(
+		input.Weight,
+		"적립 비중은 숫자로 입력해 주세요.",
+		"적립 비중은 0~100 사이로 입력해 주세요.",
+		input.Amount,
+		"적립 금액은 숫자로 입력해 주세요.",
+	)
+	if err != nil {
+		return err
+	}
+
+	note := strings.TrimSpace(input.Note)
+
+	return withQueries(func(queries *db.Queries) error {
+		if err := queries.CreateContributionPlan(ctx, db.CreateContributionPlanParams{
+			Uid:        uid,
+			SecurityID: securityID,
+			Weight:     weight,
+			Amount:     amount,
+			Note:       note,
+		}); err != nil {
+			return fmt.Errorf("적립 계획 저장 실패: %w", err)
+		}
+		return nil
+	})
+}
+
+func parseIntField(raw string, message string) (int64, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil {
+		return 0, &ValidationError{Message: message}
+	}
+	return value, nil
+}
+
+func parseFloatField(raw string, message string) (float64, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return 0, &ValidationError{Message: message}
+	}
+	return value, nil
+}
+
+func parsePercentageField(raw string, parseMessage string, rangeMessage string) (float64, error) {
+	value, err := parseFloatField(raw, parseMessage)
+	if err != nil {
+		return 0, err
+	}
+	if value < 0 || value > 100 {
+		return 0, &ValidationError{Message: rangeMessage}
+	}
+	return value, nil
+}
+
+func parseWeightAndAmount(weightRaw string, weightParseMessage string, weightRangeMessage string, amountRaw string, amountMessage string) (float64, int64, error) {
+	weight, err := parsePercentageField(weightRaw, weightParseMessage, weightRangeMessage)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	amount, err := parseIntField(amountRaw, amountMessage)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return weight, amount, nil
+}
+
+func isValidCategoryRole(role string) bool {
+	switch role {
+	case "liquidity", "growth", "income", "protection", "other":
+		return true
+	default:
+		return false
+	}
+}
+
+func withQueries(action func(*db.Queries) error) error {
+	queries, err := db.GetQueries()
+	if err != nil {
+		return fmt.Errorf("쿼리 초기화 실패: %w", err)
+	}
+	return action(queries)
+}
+
+func isValidSecurityType(t string) bool {
+	switch t {
+	case "stock", "etf", "fund", "bond", "crypto", "other":
+		return true
+	default:
+		return false
+	}
+}

--- a/projects/portfolio/services/portfolio.go
+++ b/projects/portfolio/services/portfolio.go
@@ -1,0 +1,374 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"simple-server/projects/portfolio/db"
+)
+
+const DemoUID = "uid_demo_portfolio"
+
+type PortfolioSnapshot struct {
+	UID                 string
+	TotalAsset          int64
+	Categories          []CategorySummary
+	Securities          []SecuritySummary
+	CategoryAllocations []CategoryAllocation
+	Accounts            []Account
+	Holdings            []Holding
+	RebalanceGaps       []RebalanceGap
+	BudgetEntries       []BudgetEntry
+	ContributionPlans   []ContributionPlan
+	IsDemo              bool
+}
+
+type CategorySummary struct {
+	ID           string
+	Name         string
+	Role         string
+	ParentID     string
+	DisplayOrder int64
+}
+
+type CategoryAllocation struct {
+	CategoryID   string
+	CategoryName string
+	Amount       int64
+	WeightPct    float64
+}
+
+type SecuritySummary struct {
+	ID         string
+	Name       string
+	Symbol     string
+	Type       string
+	CategoryID string
+	Currency   string
+	Note       string
+}
+
+type Account struct {
+	ID             string
+	Name           string
+	Provider       string
+	CategoryName   string
+	Balance        int64
+	MonthlyContrib int64
+	Note           string
+}
+
+type Holding struct {
+	ID             string
+	SecurityID     string
+	SecurityName   string
+	SecuritySymbol string
+	SecurityType   string
+	CategoryName   string
+	Currency       string
+	Amount         int64
+	TargetAmount   int64
+	Note           string
+}
+
+type RebalanceGap struct {
+	CategoryID     string
+	CategoryName   string
+	TargetWeight   float64
+	TargetAmount   int64
+	CurrentAmount  int64
+	TargetByWeight int64
+	TargetFinal    int64
+	GapAmount      int64
+}
+
+type BudgetEntry struct {
+	ID        string
+	Name      string
+	Direction string
+	Class     string
+	Planned   int64
+	Actual    int64
+	Note      string
+}
+
+type ContributionPlan struct {
+	ID             string
+	SecurityID     string
+	SecurityName   string
+	SecuritySymbol string
+	CategoryName   string
+	Weight         float64
+	Amount         int64
+	Note           string
+}
+
+func LoadPortfolio(ctx context.Context, uid string) (*PortfolioSnapshot, error) {
+        queries, err := db.GetQueries()
+        if err != nil {
+                return nil, fmt.Errorf("쿼리 초기화 실패: %w", err)
+        }
+
+        snapshot := &PortfolioSnapshot{UID: uid, IsDemo: uid == DemoUID}
+
+        total, err := queries.GetTotalAsset(ctx, uid)
+        if err != nil {
+                if !errors.Is(err, sql.ErrNoRows) {
+                        return nil, fmt.Errorf("총자산 조회 실패: %w", err)
+                }
+        } else {
+                snapshot.TotalAsset = total.TotalAmount
+        }
+
+        fillers := []func(context.Context, *db.Queries, *PortfolioSnapshot) error{
+                fillCategories,
+                fillSecurities,
+                fillCategoryAllocations,
+                fillAccounts,
+                fillHoldings,
+                fillRebalanceGaps,
+                fillBudgetEntries,
+                fillContributionPlans,
+        }
+        for _, filler := range fillers {
+                if err := filler(ctx, queries, snapshot); err != nil {
+                        return nil, err
+                }
+        }
+
+        return snapshot, nil
+}
+
+func fillCategories(ctx context.Context, queries *db.Queries, snapshot *PortfolioSnapshot) error {
+	rows, err := queries.ListCategories(ctx, snapshot.UID)
+	if err != nil {
+		return fmt.Errorf("카테고리 목록 조회 실패: %w", err)
+	}
+
+	snapshot.Categories = make([]CategorySummary, 0, len(rows))
+	for _, row := range rows {
+		snapshot.Categories = append(snapshot.Categories, CategorySummary{
+			ID:           row.ID,
+			Name:         row.Name,
+			Role:         row.Role,
+			ParentID:     nullString(row.ParentID),
+			DisplayOrder: row.DisplayOrder,
+		})
+	}
+	return nil
+}
+
+func fillSecurities(ctx context.Context, queries *db.Queries, snapshot *PortfolioSnapshot) error {
+	rows, err := queries.ListSecurities(ctx, snapshot.UID)
+	if err != nil {
+		return fmt.Errorf("종목 목록 조회 실패: %w", err)
+	}
+
+	snapshot.Securities = make([]SecuritySummary, 0, len(rows))
+	for _, row := range rows {
+		snapshot.Securities = append(snapshot.Securities, SecuritySummary{
+			ID:         row.ID,
+			Name:       row.Name,
+			Symbol:     row.Symbol,
+			Type:       row.Type,
+			CategoryID: nullString(row.CategoryID),
+			Currency:   row.Currency,
+			Note:       row.Note,
+		})
+	}
+	return nil
+}
+
+func fillCategoryAllocations(ctx context.Context, queries *db.Queries, snapshot *PortfolioSnapshot) error {
+	rows, err := queries.ListCategoryAllocations(ctx, snapshot.UID)
+	if err != nil {
+		return fmt.Errorf("카테고리 배분 조회 실패: %w", err)
+	}
+
+	snapshot.CategoryAllocations = make([]CategoryAllocation, 0, len(rows))
+	for _, row := range rows {
+		amount, err := toInt64(row.Amount)
+		if err != nil {
+			return fmt.Errorf("카테고리 금액 변환 실패: %w", err)
+		}
+		snapshot.CategoryAllocations = append(snapshot.CategoryAllocations, CategoryAllocation{
+			CategoryID:   row.CategoryID,
+			CategoryName: row.CategoryName,
+			Amount:       amount,
+			WeightPct:    row.WeightPct,
+		})
+	}
+	return nil
+}
+
+func fillAccounts(ctx context.Context, queries *db.Queries, snapshot *PortfolioSnapshot) error {
+	rows, err := queries.ListAccounts(ctx, snapshot.UID)
+	if err != nil {
+		return fmt.Errorf("계좌 조회 실패: %w", err)
+	}
+
+	snapshot.Accounts = make([]Account, 0, len(rows))
+	for _, row := range rows {
+		snapshot.Accounts = append(snapshot.Accounts, Account{
+			ID:             row.ID,
+			Name:           row.Name,
+			Provider:       row.Provider,
+			CategoryName:   row.CategoryName,
+			Balance:        row.Balance,
+			MonthlyContrib: row.MonthlyContrib,
+			Note:           row.Note,
+		})
+	}
+	return nil
+}
+
+func fillHoldings(ctx context.Context, queries *db.Queries, snapshot *PortfolioSnapshot) error {
+	rows, err := queries.ListHoldings(ctx, snapshot.UID)
+	if err != nil {
+		return fmt.Errorf("보유 종목 조회 실패: %w", err)
+	}
+
+	snapshot.Holdings = make([]Holding, 0, len(rows))
+	for _, row := range rows {
+		snapshot.Holdings = append(snapshot.Holdings, Holding{
+			ID:             row.ID,
+			SecurityID:     row.SecurityID,
+			SecurityName:   row.SecurityName,
+			SecuritySymbol: row.SecuritySymbol,
+			SecurityType:   row.SecurityType,
+			CategoryName:   nullString(row.CategoryName),
+			Currency:       row.SecurityCurrency,
+			Amount:         row.Amount,
+			TargetAmount:   row.TargetAmount,
+			Note:           row.Note,
+		})
+	}
+	return nil
+}
+
+func fillRebalanceGaps(ctx context.Context, queries *db.Queries, snapshot *PortfolioSnapshot) error {
+	rows, err := queries.ListRebalanceGaps(ctx, snapshot.UID)
+	if err != nil {
+		return fmt.Errorf("리밸런싱 현황 조회 실패: %w", err)
+	}
+
+	snapshot.RebalanceGaps = make([]RebalanceGap, 0, len(rows))
+	for _, row := range rows {
+		currentAmount, err := toInt64(row.CurrentAmount)
+		if err != nil {
+			return fmt.Errorf("현재 금액 변환 실패: %w", err)
+		}
+		targetFinal, err := toInt64(row.TargetFinal)
+		if err != nil {
+			return fmt.Errorf("목표 금액 변환 실패: %w", err)
+		}
+		snapshot.RebalanceGaps = append(snapshot.RebalanceGaps, RebalanceGap{
+			CategoryID:     row.CategoryID,
+			CategoryName:   row.CategoryName,
+			TargetWeight:   row.TargetWeight,
+			TargetAmount:   row.TargetAmount,
+			CurrentAmount:  currentAmount,
+			TargetByWeight: int64(math.Round(row.TargetByWeight)),
+			TargetFinal:    targetFinal,
+			GapAmount:      row.GapAmount,
+		})
+	}
+	return nil
+}
+
+func fillBudgetEntries(ctx context.Context, queries *db.Queries, snapshot *PortfolioSnapshot) error {
+	rows, err := queries.ListBudgetEntries(ctx, snapshot.UID)
+	if err != nil {
+		return fmt.Errorf("예산 항목 조회 실패: %w", err)
+	}
+
+	snapshot.BudgetEntries = make([]BudgetEntry, 0, len(rows))
+	for _, row := range rows {
+		snapshot.BudgetEntries = append(snapshot.BudgetEntries, BudgetEntry{
+			ID:        row.ID,
+			Name:      row.Name,
+			Direction: row.Direction,
+			Class:     row.Class,
+			Planned:   row.Planned,
+			Actual:    row.Actual,
+			Note:      row.Note,
+		})
+	}
+	return nil
+}
+
+func fillContributionPlans(ctx context.Context, queries *db.Queries, snapshot *PortfolioSnapshot) error {
+	rows, err := queries.ListContributionPlans(ctx, snapshot.UID)
+	if err != nil {
+		return fmt.Errorf("적립 계획 조회 실패: %w", err)
+	}
+
+	snapshot.ContributionPlans = make([]ContributionPlan, 0, len(rows))
+	for _, row := range rows {
+		snapshot.ContributionPlans = append(snapshot.ContributionPlans, ContributionPlan{
+			ID:             row.ID,
+			SecurityID:     row.SecurityID,
+			SecurityName:   row.SecurityName,
+			SecuritySymbol: row.SecuritySymbol,
+			CategoryName:   nullString(row.CategoryName),
+			Weight:         row.Weight,
+			Amount:         row.Amount,
+			Note:           row.Note,
+		})
+	}
+	return nil
+}
+
+func toInt64(value interface{}) (int64, error) {
+	switch v := value.(type) {
+	case nil:
+		return 0, nil
+	case int64:
+		return v, nil
+	case int32:
+		return int64(v), nil
+	case int:
+		return int64(v), nil
+	case float64:
+		return int64(math.Round(v)), nil
+	case float32:
+		return int64(math.Round(float64(v))), nil
+	case []byte:
+		return parseNumericString(string(v))
+	case string:
+		return parseNumericString(v)
+	default:
+		return 0, fmt.Errorf("지원하지 않는 숫자 타입: %T", value)
+	}
+}
+
+func parseNumericString(raw string) (int64, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, nil
+	}
+	if strings.Contains(trimmed, ".") {
+		f, err := strconv.ParseFloat(trimmed, 64)
+		if err != nil {
+			return 0, err
+		}
+		return int64(math.Round(f)), nil
+	}
+	i, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return i, nil
+}
+
+func nullString(ns sql.NullString) string {
+	if ns.Valid {
+		return ns.String
+	}
+	return ""
+}

--- a/projects/portfolio/views/index.go
+++ b/projects/portfolio/views/index.go
@@ -1,7 +1,12 @@
 package views
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	"simple-server/pkg/util/gomutil"
+	"simple-server/projects/portfolio/services"
 	shared "simple-server/shared/views"
 
 	. "maragu.dev/gomponents"
@@ -9,7 +14,92 @@ import (
 	. "maragu.dev/gomponents/html"
 )
 
-func Index(title string) Node {
+var (
+	categoryRoleOptions = []struct {
+		value string
+		label string
+	}{
+		{"liquidity", "유동성"},
+		{"growth", "성장"},
+		{"income", "인컴"},
+		{"protection", "안정"},
+		{"other", "기타"},
+	}
+	securityTypeOptions = []struct {
+		value string
+		label string
+	}{
+		{"stock", "주식"},
+		{"etf", "ETF"},
+		{"fund", "펀드"},
+		{"bond", "채권"},
+		{"crypto", "가상자산"},
+		{"other", "기타"},
+	}
+	budgetDirectionOptions = []struct {
+		value string
+		label string
+	}{
+		{"income", "수입"},
+		{"expense", "지출"},
+	}
+	budgetClassOptions = []struct {
+		value string
+		label string
+	}{
+		{"fixed", "고정"},
+		{"variable", "유동"},
+	}
+)
+
+func categorySelectOptions(categories []services.CategorySummary) []Node {
+	options := make([]Node, 0, len(categories)+1)
+	options = append(options, Option(Value(""), Text("선택해 주세요")))
+	for _, category := range categories {
+		label := category.Name
+		if roleLabel := categoryRoleLabel(category.Role); roleLabel != "" {
+			label = fmt.Sprintf("%s (%s)", label, roleLabel)
+		}
+		options = append(options, Option(Value(category.ID), Text(label)))
+	}
+	return options
+}
+
+func securitySelectOptions(securities []services.SecuritySummary) []Node {
+	options := make([]Node, 0, len(securities)+1)
+	options = append(options, Option(Value(""), Text("선택해 주세요")))
+	for _, security := range securities {
+		label := security.Name
+		if strings.TrimSpace(security.Symbol) != "" {
+			label = fmt.Sprintf("%s (%s)", label, security.Symbol)
+		}
+		label = fmt.Sprintf("%s - %s", label, securityTypeLabel(security.Type))
+		options = append(options, Option(Value(security.ID), Text(label)))
+	}
+	return options
+}
+
+func optionsFromList(items []struct {
+	value string
+	label string
+}) []Node {
+	options := []Node{Option(
+		Value(""),
+		Attr("disabled", "disabled"),
+		Attr("selected", "selected"),
+		Text("선택해 주세요"),
+	)}
+	for _, item := range items {
+		options = append(options, Option(Value(item.value), Text(item.label)))
+	}
+	return options
+}
+
+func Index(title string, snapshot *services.PortfolioSnapshot) Node {
+	if snapshot == nil {
+		snapshot = &services.PortfolioSnapshot{}
+	}
+
 	return HTML5(HTML5Props{
 		Title:    title,
 		Language: "ko",
@@ -23,6 +113,635 @@ func Index(title string) Node {
 		),
 		Body: []Node{
 			shared.Snackbar(),
+			Main(Class("container"),
+				Div(Class("max-width-3 margin-auto padding"),
+					H1(Class("margin-bottom"), Text("포트폴리오 대시보드")),
+					If(snapshot.IsDemo,
+						Div(Class("note warning margin-bottom"),
+							Text("로그인이 되어 있지 않아 데모 데이터를 보여주고 있어요."),
+						),
+					),
+					Div(
+						ID("portfolio-dashboard"),
+						DashboardContent(snapshot),
+					),
+				),
+			),
 		},
 	})
+}
+
+func DashboardContent(snapshot *services.PortfolioSnapshot) Node {
+	return Group([]Node{
+		TotalSection(snapshot),
+		CategorySection(snapshot),
+		RebalanceSection(snapshot),
+		SecuritySection(snapshot),
+		AccountSection(snapshot),
+		HoldingSection(snapshot),
+		BudgetSection(snapshot),
+		ContributionSection(snapshot),
+	})
+}
+
+func cardSection(id string, title string, form Node, headers []string, rows []Node) Node {
+	headerNodes := make([]Node, 0, len(headers))
+	for _, text := range headers {
+		headerNodes = append(headerNodes, Th(Text(text)))
+	}
+
+	children := []Node{H2(Text(title))}
+	if form != nil {
+		children = append(children, Div(Class("margin-bottom"), form))
+	}
+	children = append(children,
+		Table(
+			THead(Tr(headerNodes...)),
+			TBody(Group(rows)),
+		),
+	)
+
+	return Section(
+		ID(id),
+		Class("card margin-bottom"),
+		Group(children),
+	)
+}
+
+func TotalSection(snapshot *services.PortfolioSnapshot) Node {
+	return Section(
+		ID("total-section"),
+		Class("card margin-bottom"),
+		H2(Text("총자산")),
+		Strong(Class("text-large"), Text(formatCurrency(snapshot.TotalAsset))),
+	)
+}
+
+func CategorySection(snapshot *services.PortfolioSnapshot) Node {
+	headers := []string{"카테고리", "현재 금액", "비중"}
+	rows := make([]Node, 0, len(snapshot.CategoryAllocations))
+	for _, item := range snapshot.CategoryAllocations {
+		rows = append(rows, Tr(
+			Td(Text(item.CategoryName)),
+			Td(Text(formatCurrency(item.Amount))),
+			Td(Text(formatPercent(item.WeightPct))),
+		))
+	}
+	rows = ensureRows(rows, len(headers), "카테고리 데이터가 없습니다.")
+
+	var form Node
+	if !snapshot.IsDemo {
+		form = categoryForm(snapshot.Categories)
+	}
+
+	return cardSection(
+		"category-section",
+		"카테고리별 자산 배분",
+		form,
+		headers,
+		rows,
+	)
+}
+
+func RebalanceSection(snapshot *services.PortfolioSnapshot) Node {
+	headers := []string{"카테고리", "목표 비중", "목표 금액", "비중 기준 목표", "현재 금액", "차이"}
+	rows := make([]Node, 0, len(snapshot.RebalanceGaps))
+	for _, item := range snapshot.RebalanceGaps {
+		rows = append(rows, Tr(
+			Td(Text(item.CategoryName)),
+			Td(Text(formatPercent(item.TargetWeight))),
+			Td(Text(formatCurrency(item.TargetAmount))),
+			Td(Text(formatCurrency(item.TargetByWeight))),
+			Td(Text(formatCurrency(item.CurrentAmount))),
+			Td(Text(formatSignedCurrency(item.GapAmount))),
+		))
+	}
+	rows = ensureRows(rows, len(headers), "리밸런싱 목표 데이터가 없습니다.")
+
+	var form Node
+	if !snapshot.IsDemo {
+		form = allocationTargetForm(snapshot.Categories)
+	}
+
+	return cardSection(
+		"rebalance-section",
+		"리밸런싱 목표 대비 현황",
+		form,
+		headers,
+		rows,
+	)
+}
+
+func SecuritySection(snapshot *services.PortfolioSnapshot) Node {
+	headers := []string{"종목", "심볼", "유형", "카테고리", "통화", "메모"}
+	rows := make([]Node, 0, len(snapshot.Securities))
+	for _, item := range snapshot.Securities {
+		rows = append(rows, Tr(
+			Td(Text(item.Name)),
+			Td(Text(emptyFallback(item.Symbol))),
+			Td(Text(securityTypeLabel(item.Type))),
+			Td(Text(emptyFallback(findCategoryName(snapshot.Categories, item.CategoryID)))),
+			Td(Text(item.Currency)),
+			Td(Text(formatNote(item.Note))),
+		))
+	}
+	rows = ensureRows(rows, len(headers), "종목 데이터가 없습니다.")
+
+	var form Node
+	if !snapshot.IsDemo {
+		form = securityForm(snapshot.Categories)
+	}
+
+	return cardSection(
+		"security-section",
+		"종목 마스터",
+		form,
+		headers,
+		rows,
+	)
+}
+
+func AccountSection(snapshot *services.PortfolioSnapshot) Node {
+	headers := []string{"계좌명", "기관", "카테고리", "잔액", "월 납입", "메모"}
+	rows := make([]Node, 0, len(snapshot.Accounts))
+	for _, item := range snapshot.Accounts {
+		rows = append(rows, Tr(
+			Td(Text(item.Name)),
+			Td(Text(item.Provider)),
+			Td(Text(item.CategoryName)),
+			Td(Text(formatCurrency(item.Balance))),
+			Td(Text(formatCurrency(item.MonthlyContrib))),
+			Td(Text(formatNote(item.Note))),
+		))
+	}
+	rows = ensureRows(rows, len(headers), "계좌 데이터가 없습니다.")
+
+	var form Node
+	if !snapshot.IsDemo {
+		form = accountForm(snapshot.Categories)
+	}
+
+	return cardSection(
+		"account-section",
+		"계좌 현황",
+		form,
+		headers,
+		rows,
+	)
+}
+
+func HoldingSection(snapshot *services.PortfolioSnapshot) Node {
+	headers := []string{"종목", "심볼", "유형", "카테고리", "현재 금액", "목표 금액", "메모"}
+	rows := make([]Node, 0, len(snapshot.Holdings))
+	for _, item := range snapshot.Holdings {
+		rows = append(rows, Tr(
+			Td(Text(item.SecurityName)),
+			Td(Text(item.SecuritySymbol)),
+			Td(Text(securityTypeLabel(item.SecurityType))),
+			Td(Text(emptyFallback(item.CategoryName))),
+			Td(Text(formatCurrency(item.Amount))),
+			Td(Text(formatCurrency(item.TargetAmount))),
+			Td(Text(formatNote(item.Note))),
+		))
+	}
+	rows = ensureRows(rows, len(headers), "보유 종목 데이터가 없습니다.")
+
+	var form Node
+	if !snapshot.IsDemo {
+		form = holdingForm(snapshot.Securities)
+	}
+
+	return cardSection(
+		"holding-section",
+		"보유 종목",
+		form,
+		headers,
+		rows,
+	)
+}
+
+func BudgetSection(snapshot *services.PortfolioSnapshot) Node {
+	headers := []string{"항목", "구분", "유형", "계획", "실적", "메모"}
+	rows := make([]Node, 0, len(snapshot.BudgetEntries))
+	for _, item := range snapshot.BudgetEntries {
+		rows = append(rows, Tr(
+			Td(Text(item.Name)),
+			Td(Text(directionLabel(item.Direction))),
+			Td(Text(classLabel(item.Class))),
+			Td(Text(formatCurrency(item.Planned))),
+			Td(Text(formatCurrency(item.Actual))),
+			Td(Text(formatNote(item.Note))),
+		))
+	}
+	rows = ensureRows(rows, len(headers), "예산 데이터가 없습니다.")
+
+	var form Node
+	if !snapshot.IsDemo {
+		form = budgetForm()
+	}
+
+	return cardSection(
+		"budget-section",
+		"월 수입/지출",
+		form,
+		headers,
+		rows,
+	)
+}
+
+func ContributionSection(snapshot *services.PortfolioSnapshot) Node {
+	headers := []string{"종목", "심볼", "카테고리", "비중", "월 적립액", "메모"}
+	rows := make([]Node, 0, len(snapshot.ContributionPlans))
+	for _, item := range snapshot.ContributionPlans {
+		rows = append(rows, Tr(
+			Td(Text(item.SecurityName)),
+			Td(Text(item.SecuritySymbol)),
+			Td(Text(emptyFallback(item.CategoryName))),
+			Td(Text(formatPercentOne(item.Weight))),
+			Td(Text(formatCurrency(item.Amount))),
+			Td(Text(formatNote(item.Note))),
+		))
+	}
+	rows = ensureRows(rows, len(headers), "월 적립 계획 데이터가 없습니다.")
+
+	var form Node
+	if !snapshot.IsDemo {
+		form = contributionForm(snapshot.Securities)
+	}
+
+	return cardSection(
+		"contribution-section",
+		"주식 월 적립 계획",
+		form,
+		headers,
+		rows,
+	)
+}
+
+func hxForm(action string, submitLabel string, fields ...Node) Node {
+	nodes := make([]Node, 0, len(fields)+1)
+	nodes = append(nodes, fields...)
+	nodes = append(nodes, Div(Class("form-actions"), Button(Class("button primary"), Type("submit"), Text(submitLabel))))
+
+	return Form(
+		Class("grid gap-small"),
+		Method("post"),
+		Attr("hx-post", action),
+		Attr("hx-target", "#portfolio-dashboard"),
+		Attr("hx-swap", "innerHTML"),
+		Group(nodes),
+	)
+}
+
+func categoryForm(categories []services.CategorySummary) Node {
+	return hxForm(
+		"/categories",
+		"카테고리 추가",
+		Div(Class("field"),
+			Label(For("category-name"), Text("카테고리명")),
+			Input(ID("category-name"), Name("name"), Type("text"), Attr("required", "required")),
+		),
+		Div(Class("field"),
+			Label(For("category-role"), Text("역할")),
+			Select(
+				ID("category-role"),
+				Name("role"),
+				Attr("required", "required"),
+				Group(optionsFromList(categoryRoleOptions)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("category-parent"), Text("상위 카테고리")),
+			Select(
+				ID("category-parent"),
+				Name("parent_id"),
+				Group(categorySelectOptions(categories)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("category-order"), Text("정렬 순서")),
+			Input(ID("category-order"), Name("display_order"), Type("number"), Attr("min", "0")),
+		),
+	)
+}
+
+func allocationTargetForm(categories []services.CategorySummary) Node {
+	return hxForm(
+		"/allocation-targets",
+		"목표 추가",
+		Div(Class("field"),
+			Label(For("target-category"), Text("카테고리")),
+			Select(
+				ID("target-category"),
+				Name("category_id"),
+				Attr("required", "required"),
+				Group(categorySelectOptions(categories)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("target-weight"), Text("목표 비중(%)")),
+			Input(ID("target-weight"), Name("target_weight"), Type("number"), Attr("step", "0.1"), Attr("min", "0"), Attr("max", "100")),
+		),
+		Div(Class("field"),
+			Label(For("target-amount"), Text("목표 금액")),
+			Input(ID("target-amount"), Name("target_amount"), Type("number"), Attr("min", "0")),
+		),
+		Div(Class("field"),
+			Label(For("target-note"), Text("메모")),
+			Textarea(ID("target-note"), Name("note"), Attr("rows", "2")),
+		),
+	)
+}
+
+func securityForm(categories []services.CategorySummary) Node {
+	return hxForm(
+		"/securities",
+		"종목 추가",
+		Div(Class("field"),
+			Label(For("security-name"), Text("종목명")),
+			Input(ID("security-name"), Name("name"), Type("text"), Attr("required", "required")),
+		),
+		Div(Class("field"),
+			Label(For("security-symbol"), Text("심볼")),
+			Input(ID("security-symbol"), Name("symbol"), Type("text")),
+		),
+		Div(Class("field"),
+			Label(For("security-type"), Text("유형")),
+			Select(
+				ID("security-type"),
+				Name("type"),
+				Attr("required", "required"),
+				Group(optionsFromList(securityTypeOptions)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("security-category"), Text("카테고리")),
+			Select(
+				ID("security-category"),
+				Name("category_id"),
+				Group(categorySelectOptions(categories)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("security-currency"), Text("통화")),
+			Input(ID("security-currency"), Name("currency"), Type("text"), Attr("value", "KRW")),
+		),
+		Div(Class("field"),
+			Label(For("security-note"), Text("메모")),
+			Textarea(ID("security-note"), Name("note"), Attr("rows", "2")),
+		),
+	)
+}
+
+func accountForm(categories []services.CategorySummary) Node {
+	return hxForm(
+		"/accounts",
+		"계좌 추가",
+		Div(Class("field"),
+			Label(For("account-name"), Text("계좌명")),
+			Input(ID("account-name"), Name("name"), Type("text"), Attr("required", "required")),
+		),
+		Div(Class("field"),
+			Label(For("account-provider"), Text("기관")),
+			Input(ID("account-provider"), Name("provider"), Type("text")),
+		),
+		Div(Class("field"),
+			Label(For("account-category"), Text("카테고리")),
+			Select(
+				ID("account-category"),
+				Name("category_id"),
+				Attr("required", "required"),
+				Group(categorySelectOptions(categories)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("account-balance"), Text("잔액")),
+			Input(ID("account-balance"), Name("balance"), Type("number"), Attr("min", "0")),
+		),
+		Div(Class("field"),
+			Label(For("account-monthly"), Text("월 납입")),
+			Input(ID("account-monthly"), Name("monthly_contrib"), Type("number"), Attr("min", "0")),
+		),
+		Div(Class("field"),
+			Label(For("account-note"), Text("메모")),
+			Textarea(ID("account-note"), Name("note"), Attr("rows", "2")),
+		),
+	)
+}
+
+func holdingForm(securities []services.SecuritySummary) Node {
+	return hxForm(
+		"/holdings",
+		"보유 종목 추가",
+		Div(Class("field"),
+			Label(For("holding-security"), Text("종목")),
+			Select(
+				ID("holding-security"),
+				Name("security_id"),
+				Attr("required", "required"),
+				Group(securitySelectOptions(securities)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("holding-amount"), Text("현재 금액")),
+			Input(ID("holding-amount"), Name("amount"), Type("number"), Attr("min", "0"), Attr("required", "required")),
+		),
+		Div(Class("field"),
+			Label(For("holding-target"), Text("목표 금액")),
+			Input(ID("holding-target"), Name("target_amount"), Type("number"), Attr("min", "0")),
+		),
+		Div(Class("field"),
+			Label(For("holding-note"), Text("메모")),
+			Textarea(ID("holding-note"), Name("note"), Attr("rows", "2")),
+		),
+	)
+}
+
+func budgetForm() Node {
+	return hxForm(
+		"/budget-entries",
+		"예산 추가",
+		Div(Class("field"),
+			Label(For("budget-name"), Text("항목")),
+			Input(ID("budget-name"), Name("name"), Type("text"), Attr("required", "required")),
+		),
+		Div(Class("field"),
+			Label(For("budget-direction"), Text("구분")),
+			Select(
+				ID("budget-direction"),
+				Name("direction"),
+				Attr("required", "required"),
+				Group(optionsFromList(budgetDirectionOptions)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("budget-class"), Text("유형")),
+			Select(
+				ID("budget-class"),
+				Name("class"),
+				Attr("required", "required"),
+				Group(optionsFromList(budgetClassOptions)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("budget-planned"), Text("계획 금액")),
+			Input(ID("budget-planned"), Name("planned"), Type("number"), Attr("min", "0")),
+		),
+		Div(Class("field"),
+			Label(For("budget-actual"), Text("실제 금액")),
+			Input(ID("budget-actual"), Name("actual"), Type("number"), Attr("min", "0")),
+		),
+		Div(Class("field"),
+			Label(For("budget-note"), Text("메모")),
+			Textarea(ID("budget-note"), Name("note"), Attr("rows", "2")),
+		),
+	)
+}
+
+func contributionForm(securities []services.SecuritySummary) Node {
+	return hxForm(
+		"/contribution-plans",
+		"적립 계획 추가",
+		Div(Class("field"),
+			Label(For("plan-security"), Text("종목")),
+			Select(
+				ID("plan-security"),
+				Name("security_id"),
+				Attr("required", "required"),
+				Group(securitySelectOptions(securities)),
+			),
+		),
+		Div(Class("field"),
+			Label(For("plan-weight"), Text("비중(%)")),
+			Input(ID("plan-weight"), Name("weight"), Type("number"), Attr("step", "0.1"), Attr("min", "0"), Attr("max", "100")),
+		),
+		Div(Class("field"),
+			Label(For("plan-amount"), Text("월 적립액")),
+			Input(ID("plan-amount"), Name("amount"), Type("number"), Attr("min", "0")),
+		),
+		Div(Class("field"),
+			Label(For("plan-note"), Text("메모")),
+			Textarea(ID("plan-note"), Name("note"), Attr("rows", "2")),
+		),
+	)
+}
+
+func ensureRows(rows []Node, cols int, emptyMessage string) []Node {
+	if len(rows) > 0 {
+		return rows
+	}
+	return []Node{
+		Tr(
+			Td(Attr("colspan", strconv.Itoa(cols)), Class("text-center"), Text(emptyMessage)),
+		),
+	}
+}
+
+func formatCurrency(amount int64) string {
+	return formatCurrencyInternal(amount, false)
+}
+
+func formatSignedCurrency(amount int64) string {
+	return formatCurrencyInternal(amount, true)
+}
+
+func formatCurrencyInternal(amount int64, signed bool) string {
+	sign := ""
+	value := amount
+	if value < 0 {
+		sign = "-"
+		value = -value
+	} else if signed {
+		sign = "+"
+	}
+
+	digits := strconv.FormatInt(value, 10)
+	var builder strings.Builder
+	for i, digit := range digits {
+		if i > 0 && (len(digits)-i)%3 == 0 {
+			builder.WriteRune(',')
+		}
+		builder.WriteRune(digit)
+	}
+
+	return fmt.Sprintf("%s%s원", sign, builder.String())
+}
+
+func formatPercent(value float64) string {
+	return fmt.Sprintf("%.2f%%", value)
+}
+
+func formatPercentOne(value float64) string {
+	return fmt.Sprintf("%.1f%%", value)
+}
+
+func formatNote(note string) string {
+	if strings.TrimSpace(note) == "" {
+		return "-"
+	}
+	return note
+}
+
+func categoryRoleLabel(role string) string {
+	for _, item := range categoryRoleOptions {
+		if item.value == role {
+			return item.label
+		}
+	}
+	return ""
+}
+
+func findCategoryName(categories []services.CategorySummary, id string) string {
+	for _, category := range categories {
+		if category.ID == id {
+			return category.Name
+		}
+	}
+	return ""
+}
+
+func directionLabel(direction string) string {
+	switch direction {
+	case "income":
+		return "수입"
+	case "expense":
+		return "지출"
+	default:
+		return direction
+	}
+}
+
+func classLabel(class string) string {
+	switch class {
+	case "fixed":
+		return "고정"
+	case "variable":
+		return "유동"
+	default:
+		return class
+	}
+}
+
+func securityTypeLabel(t string) string {
+	switch t {
+	case "stock":
+		return "주식"
+	case "etf":
+		return "ETF"
+	case "fund":
+		return "펀드"
+	case "bond":
+		return "채권"
+	case "crypto":
+		return "가상자산"
+	default:
+		return "기타"
+	}
+}
+
+func emptyFallback(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
 }


### PR DESCRIPTION
## Summary
- 포트폴리오 항목 생성용 서비스와 검증 로직을 추가하고 SQLC 쿼리를 확장했습니다.
- 새 저장 핸들러와 보호 라우트를 등록해 HTMX 폼 제출 시 대시보드를 갱신합니다.
- 대시보드 섹션을 카드 헬퍼와 재사용 가능한 HX 폼으로 리팩터링하고 입력 UI를 추가했습니다.

## Testing
- `bash task.sh check`


------
https://chatgpt.com/codex/tasks/task_e_68cbc2520970832fa1dbca2d88ba7301